### PR TITLE
Fix: on-screen keyboard covers the lower half of the page in the browser view

### DIFF
--- a/apps/mobile/android/app/src/main/java/io/github/sayach/dshmobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/java/io/github/sayach/dshmobile/MainActivity.kt
@@ -936,12 +936,24 @@ class MainActivity : Activity() {
         setContentView(root)
 
         // Keep the toolbar clear of the status bar; the loading bar sits below it.
-        root.setOnApplyWindowInsetsListener { _, insets ->
+        root.setOnApplyWindowInsetsListener { view, insets ->
             val top = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 insets.getInsets(WindowInsets.Type.statusBars()).top
             } else {
                 @Suppress("DEPRECATION")
                 insets.systemWindowInsetTop
+            }
+            // The on-screen keyboard covers the lower half of this edge-to-edge
+            // window because setDecorFitsSystemWindows(false) disables the
+            // automatic adjustResize resize on Android 11+ (and the legacy layout
+            // flags do the same on older versions). The shell must apply the IME
+            // inset itself: shrink the WebView so the page reflows to sit above
+            // the keyboard and the focused input stays visible.
+            val imeBottom = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                insets.getInsets(WindowInsets.Type.ime()).bottom
+            } else {
+                @Suppress("DEPRECATION")
+                insets.systemWindowInsetBottom
             }
             bar.setPadding(dp(16), top, dp(4), 0)
             bar.layoutParams = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(48) + top, Gravity.TOP)
@@ -952,6 +964,10 @@ class MainActivity : Activity() {
             bar.alpha = if (toolbarHidden) 0f else 1f
             loading.translationY = bar.translationY
             loading.alpha = bar.alpha
+            // Shrink the WebView above the keyboard (0 when the keyboard is closed)
+            // while still passing the insets through, so the WebView keeps reading
+            // env(safe-area-inset-*) for the status bar and gesture bar.
+            view.setPadding(0, 0, 0, imeBottom)
             // Pass the insets through instead of consuming them: the full-screen
             // WebView computes env(safe-area-inset-top/bottom) from them, which
             // keeps the page's own header clear of the status bar.


### PR DESCRIPTION
## Summary
Fixes the on-screen keyboard overlapping the bottom half of the browser view.

### Root cause
On Android 11+ (and with the legacy edge-to-edge flags on older builds) the edge-to-edge window is not resized for the IME, so `adjustResize` has no effect and the keyboard overlays the WebView.

The browser screen's window-insets listener only handled the status-bar **top** inset and ignored the IME **bottom** inset.

### Fix
Apply the IME bottom inset as bottom padding on the root view so the full-screen WebView shrinks to sit above the keyboard (the page reflows and the focused input stays visible), while still passing insets through so the page keeps reading `env(safe-area-inset-*)`.

### Verification
Built the debug APK locally with this change; the keyboard no longer covers the lower half of the page.

Only `apps/mobile/android/.../MainActivity.kt` is changed.