### PR TITLE
ci: recognize current Android signer output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
       - uses: actions/setup-java@v6
         with:
           distribution: temurin
@@ -97,18 +100,14 @@ jobs:
         run: bash ./gradlew --no-daemon :app:dependencies --configuration releaseRuntimeClasspath > "$GITHUB_WORKSPACE/dsh-mobile-android-${GITHUB_REF_NAME}-dependencies.txt"
         working-directory: apps/mobile/android
       - name: Verify Android signature
+        shell: bash
         run: |
           apksigner="$(find "$ANDROID_HOME/build-tools" -type f -name apksigner | sort -V | tail -n 1)"
           test -x "$apksigner"
           apk="apps/mobile/android/app/build/outputs/apk/release/app-release.apk"
           report="$RUNNER_TEMP/dsh-mobile-apksigner.txt"
           "$apksigner" verify --verbose --print-certs "$apk" | tee "$report"
-          mapfile -t signer_digests < <(awk '/^Signer #[0-9]+ certificate SHA-256 digest:/ { print tolower($NF) }' "$report")
-          expected="f46bbee7dbe47d18f49f95f940e1d368f0b79bd8ad9d15d488337fba51e92e87"
-          if [ "${#signer_digests[@]}" -ne 1 ] || [ "${signer_digests[0]:-}" != "$expected" ]; then
-            echo "Android APK must have exactly one signer with the established release certificate." >&2
-            exit 1
-          fi
+          node scripts/verify-android-signature.mjs < "$report"
       - name: Enforce Android package size
         run: |
           apk="apps/mobile/android/app/build/outputs/apk/release/app-release.apk"

--- a/scripts/verify-android-signature.mjs
+++ b/scripts/verify-android-signature.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+
+// Run only after apksigner verify succeeds; this checks the established release identity.
+const expected = 'f46bbee7dbe47d18f49f95f940e1d368f0b79bd8ad9d15d488337fba51e92e87'
+const lines = readFileSync(0, 'utf8').split(/\r?\n/u).map(line => line.trim())
+const signerCounts = lines.filter(line => line.startsWith('Number of signers:'))
+const certificates = lines.filter(line => line.includes('certificate SHA-256 digest:'))
+const certificatePattern = /^(?:Signer #1|V[234](?:\.1)? Signer:) certificate SHA-256 digest: ([a-f\d]{64})$/iu
+
+if (!lines.includes('Verifies')
+  || signerCounts.length !== 1
+  || signerCounts[0] !== 'Number of signers: 1'
+  || certificates.length === 0
+  || certificates.some(line => certificatePattern.exec(line)?.[1]?.toLowerCase() !== expected)) {
+  console.error('Android APK must have exactly one signer with the established release certificate.')
+  process.exitCode = 1
+} else {
+  console.log('Android release signing certificate verified.')
+}

--- a/tests/android-signature.test.ts
+++ b/tests/android-signature.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const verifier = fileURLToPath(new URL('../scripts/verify-android-signature.mjs', import.meta.url))
+const digest = 'f46bbee7dbe47d18f49f95f940e1d368f0b79bd8ad9d15d488337fba51e92e87'
+const certificate = (label: string, value = digest): string => `${label} certificate SHA-256 digest: ${value}`
+const report = (...certificates: string[]): string => ['Verifies', 'Number of signers: 1', ...certificates].join('\n')
+
+function verify(input: string): number | null {
+  const result = spawnSync(process.execPath, [verifier], { input, encoding: 'utf8', timeout: 5_000 })
+  if (result.error) throw result.error
+  return result.status
+}
+
+describe('Android release certificate gate', () => {
+  it.each(['Signer #1', 'V2 Signer:', 'V3 Signer:', 'V3.1 Signer:', 'V4 Signer:'])('accepts the established certificate in %s output', label => {
+    expect(verify(report(certificate(label)))).toBe(0)
+  })
+
+  it('accepts one signer reported in multiple signature schemes and CRLF output', () => {
+    expect(verify(report(certificate('V2 Signer:'), certificate('V3 Signer:', digest.toUpperCase())).replaceAll('\n', '\r\n'))).toBe(0)
+  })
+
+  it.each([
+    ['', 'empty output'],
+    [report(), 'missing certificate'],
+    [report(certificate('V2 Signer:', 'a'.repeat(64))), 'different certificate'],
+    [report(certificate('V2 Signer:', 'invalid')), 'malformed digest'],
+    [report(certificate('V2 Signer:'), certificate('V3 Signer:', 'a'.repeat(64))), 'different scheme certificate'],
+    [report(certificate('Signer #1'), certificate('Signer #2')), 'additional legacy signer'],
+    [report(certificate('Unknown Signer:')), 'unknown certificate label'],
+    [report(certificate('V2 Signer:')).replace('Number of signers: 1', 'Number of signers: 2'), 'multiple signers'],
+    [report(certificate('V2 Signer:')).replace('Number of signers: 1\n', ''), 'missing signer count'],
+    [report(certificate('V2 Signer:')) + '\nNumber of signers: 1', 'ambiguous signer count'],
+    [report(certificate('V2 Signer:')).replace('Verifies', 'DOES NOT VERIFY'), 'unsuccessful verification'],
+  ])('rejects %s (%s)', (input) => {
+    expect(verify(input)).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fix the Android signature gate that blocked the first v0.3.3 release attempt. The APK was correctly signed with the established certificate, but current apksigner reports `V2 Signer:` rather than the legacy `Signer #1` label.

- Verify current and legacy reports with a dependency-free Node script.
- Require successful verification, exactly one signer, and the established SHA-256 for every reported signing certificate.
- Use explicit Bash pipefail so apksigner errors cannot be hidden by tee.
- Keep the signing key, application ID, release version, and package contents unchanged.

## Validation

- 17 focused acceptance/rejection tests passed.
- TypeScript typecheck passed.
- Replayed the actual failed release's signature report successfully.
- Workflow YAML and the explicit pipefail shell were checked.

No npm package or GitHub Release was published by the failed run. After this fix passes CI and is merged, the owner has authorized rebuilding the existing v0.3.3 tag without rewriting main history.
