### PR TITLE
Fix WebSocket upgrade payload handling for 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
+## 0.3.5 - 2026-09-01
+
+- Fix [#26](https://github.com/saya-ch/dsh-mobile/issues/26): prevent mobile startup from remaining on “Loading plugins” over LAN or remote access when DSH sends the WebSocket upgrade response and initial snapshot together. The gateway now preserves that snapshot without relaxing its 16 KiB response-header limit. Thanks @oliverwan97 for the detailed report.
+
 ## 0.3.4 - 2026-08-31
 
 - Support DeepSeek Harness 0.1.2-alpha.2, including its remote-backed settings dependencies. Initialize authenticated mobile trust before the API gateway caches Host facts, while retaining support for earlier declared DSH versions.

--- a/README.en.md
+++ b/README.en.md
@@ -19,14 +19,14 @@
 
 > DSH Mobile is a DeepSeek Harness community plugin; the native app supports Android only.
 >
-> **0.3.4 updates**: support DSH 0.1.2-alpha.2; fix directory-picker conflicts and update-profile detection in Windows DSH Desktop; improve the Mobile Access sidebar layout, dark-mode icons, and keyboard accessibility. [Details and acknowledgements](CHANGELOG.md).
+> **0.3.5 update**: fix a mobile startup hang when DSH sends a large first WebSocket payload immediately after the upgrade response; the fix applies to both LAN and remote access, and existing 0.3.3/0.3.4 apps do not need re-pairing. [Details and acknowledgements](CHANGELOG.md).
 >
 > **Upgrade reminder**: the plugin is evolving rapidly; keep it and the app updated together. DSH 0.1.2-alpha.2 requires Mobile plugin 0.3.4 or later. [Compatibility notes](#compatibility).
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.4/dsh-mobile-android-v0.3.4.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.4/dsh-mobile-android-v0.3.4.apk"><strong>Download Android app 0.3.4</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.4">Release notes and checksums</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.5/dsh-mobile-android-v0.3.5.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.5/dsh-mobile-android-v0.3.5.apk"><strong>Download Android app 0.3.5</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.5">Release notes and checksums</a></sub>
 </p>
 
 DSH Mobile is a DeepSeek Harness plugin that lets a mobile browser or the Android app connect over a protected LAN or an optional Tailscale Funnel, cpolar, or self-hosted FRP remote path. Local and remote access keep the same sessions, Workspaces, messages, and tools while using separate switches and paired-device stores without modifying DeepSeek Harness source.
@@ -190,10 +190,11 @@ See [SECURITY.md](SECURITY.md).
 
 ## Compatibility
 
-Use Mobile plugin 0.3.4 with DSH 0.1.2-alpha.2; plugin and app 0.3.2 or later are recommended for DSH 0.1.2-alpha.1. Plugin 0.3.4 remains compatible with existing 0.3.3 apps without re-pairing. Earlier apps use a different status-bar strategy, so updating both is recommended. App 0.1.3 or earlier requires reinstalling and pairing again.
+Use Mobile plugin 0.3.4 or later with DSH 0.1.2-alpha.2; plugin and app 0.3.2 or later are recommended for DSH 0.1.2-alpha.1. Plugin 0.3.5 remains compatible with existing 0.3.3/0.3.4 apps without re-pairing; the 0.3.5 Android build changes version metadata only and keeps the same behavior. Earlier apps use a different status-bar strategy, so updating both is recommended. App 0.1.3 or earlier requires reinstalling and pairing again.
 
 | DSH Mobile | Verified DeepSeek Harness releases |
 | --- | --- |
+| `0.3.5` | `0.1.0-rc.5`, `0.1.0-rc.6`, `0.1.0-rc.7`, `0.1.1-rc.2`, `0.1.2-alpha.1`, `0.1.2-alpha.2` |
 | `0.3.4` | `0.1.0-rc.5`, `0.1.0-rc.6`, `0.1.0-rc.7`, `0.1.1-rc.2`, `0.1.2-alpha.1`, `0.1.2-alpha.2` |
 | `0.3.3` | `0.1.0-rc.5`, `0.1.0-rc.6`, `0.1.0-rc.7`, `0.1.1-rc.2`, `0.1.2-alpha.1` |
 | `0.3.2` | `0.1.0-rc.5`, `0.1.0-rc.6`, `0.1.0-rc.7`, `0.1.1-rc.2`, `0.1.2-alpha.1` |

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 > DSH Mobile 是 DeepSeek Harness 社区插件，原生 App 仅支持 Android。
 >
-> **0.3.4 更新**：适配 DSH 0.1.2-alpha.2，修复 Windows DSH Desktop 目录选择器冲突及插件更新时的配置识别，优化「移动访问」侧栏入口的布局、深色模式与键盘操作。[详细记录与致谢](CHANGELOG.md)。
+> **0.3.5 更新**：修复 DSH 在 WebSocket 握手后立即发送较大首批数据时，移动端可能一直停在插件加载界面的问题，局域网与远程连接均适用；现有 0.3.3/0.3.4 App 无需重新配对。[详细记录与致谢](CHANGELOG.md)。
 >
 > **升级提醒**：插件仍在快速迭代，建议与 App 同步更新；DSH 0.1.2-alpha.2 需使用 Mobile 插件 0.3.4 或更高版本。[兼容说明](#兼容性)。
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.4/dsh-mobile-android-v0.3.4.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.4/dsh-mobile-android-v0.3.4.apk"><strong>下载 Android App 0.3.4</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.4">版本说明与校验文件</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.5/dsh-mobile-android-v0.3.5.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.5/dsh-mobile-android-v0.3.5.apk"><strong>下载 Android App 0.3.5</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.5">版本说明与校验文件</a></sub>
 </p>
 
 DSH Mobile 是一个 DeepSeek Harness 插件，让手机浏览器或 Android App 通过局域网，或可选的 Tailscale Funnel、cpolar、自建 FRP 远程通道连接电脑，继续使用同一份会话、工作区、消息和工具。局域网与远程访问分别启停、分别管理设备，且都不修改 DeepSeek Harness 源码。
@@ -199,10 +199,11 @@ flowchart LR
 
 ## 兼容性
 
-DSH 0.1.2-alpha.2 需搭配 Mobile 插件 0.3.4；DSH 0.1.2-alpha.1 建议搭配插件与 App 0.3.2 或更高版本。0.3.4 插件兼容现有 0.3.3 App，无需重新配对。更早的 App 使用不同的状态栏策略，建议同步升级；App 0.1.3 及更早版本需卸载重装并重新配对。
+DSH 0.1.2-alpha.2 需搭配 Mobile 插件 0.3.4 或更高版本；DSH 0.1.2-alpha.1 建议搭配插件与 App 0.3.2 或更高版本。0.3.5 插件兼容现有 0.3.3/0.3.4 App，无需重新配对；本次 Android App 仅同步版本号，功能行为不变。更早的 App 使用不同的状态栏策略，建议同步升级；App 0.1.3 及更早版本需卸载重装并重新配对。
 
 | DSH Mobile | 已验证的 DeepSeek Harness                                               |
 | ------------ | ------------------------------------------------------------------------- |
+| `0.3.5` | `0.1.0-rc.5`、`0.1.0-rc.6`、`0.1.0-rc.7`、`0.1.1-rc.2`、`0.1.2-alpha.1`、`0.1.2-alpha.2` |
 | `0.3.4` | `0.1.0-rc.5`、`0.1.0-rc.6`、`0.1.0-rc.7`、`0.1.1-rc.2`、`0.1.2-alpha.1`、`0.1.2-alpha.2` |
 | `0.3.3` | `0.1.0-rc.5`、`0.1.0-rc.6`、`0.1.0-rc.7`、`0.1.1-rc.2`、`0.1.2-alpha.1` |
 | `0.3.2`    | `0.1.0-rc.5`、`0.1.0-rc.6`、`0.1.0-rc.7`、`0.1.1-rc.2`、`0.1.2-alpha.1` |

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "io.github.sayach.dshmobile"
         minSdk = 29
         targetSdk = 36
-        versionCode = 49
-        versionName = "0.3.4"
+        versionCode = 50
+        versionName = "0.3.5"
     }
 
     signingConfigs {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-mobile",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "description": "DeepSeek Harness 移动端适配与安全访问插件，支持局域网、远程连接、Android App 和手机浏览器。",
   "type": "module",

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1994,12 +1994,15 @@ export class MobileAccessGateway {
       const closed = (): void => { cleanup(); reject(new Error('upstream closed during WebSocket handshake')) }
       const data = (chunk: Buffer): void => {
         buffer = Buffer.concat([buffer, chunk])
-        if (buffer.length > MAX_HEADER_BYTES) {
+        const end = buffer.indexOf('\r\n\r\n')
+        if (end < 0) {
+          if (buffer.length >= MAX_HEADER_BYTES) failed(new Error('upstream WebSocket headers are too large'))
+          return
+        }
+        if (end + 4 > MAX_HEADER_BYTES) {
           failed(new Error('upstream WebSocket headers are too large'))
           return
         }
-        const end = buffer.indexOf('\r\n\r\n')
-        if (end < 0) return
         cleanup()
         const lines = buffer.subarray(0, end).toString('latin1').split('\r\n')
         if (lines.shift() !== 'HTTP/1.1 101 Switching Protocols') {

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -169,14 +169,32 @@ function websocketAccept(key: string): string {
   return createHash('sha1').update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`, 'ascii').digest('base64')
 }
 
-async function upstream(boot: 'legacy' | 'batched' | 'remote-settings' = 'legacy', requireAuthentication = false): Promise<{
+function websocketBinaryFrame(payload: Buffer): Buffer {
+  if (payload.length > 0xffff) throw new Error('test WebSocket payload is too large')
+  const frame = Buffer.allocUnsafe(payload.length + 4)
+  frame[0] = 0x82
+  frame[1] = 126
+  frame.writeUInt16BE(payload.length, 2)
+  payload.copy(frame, 4)
+  return frame
+}
+
+async function upstream(
+  boot: 'legacy' | 'batched' | 'remote-settings' = 'legacy',
+  requireAuthentication = false,
+  upgradeBurst: Buffer = Buffer.alloc(0),
+  upgradeHeaderLines: string[] = [],
+  upgradeHeaderBytes?: number,
+): Promise<{
   port: number
   observations: UpstreamObservation[]
   upgradeObservations: IncomingHttpHeaders[]
+  upgradeResponseBytes: number[]
   releaseHold: () => void
 }> {
   const observations: UpstreamObservation[] = []
   const upgradeObservations: IncomingHttpHeaders[] = []
+  const upgradeResponseBytes: number[] = []
   const held: Array<() => void> = []
   const upgraded = new Set<Socket>()
   const server = createServer(async (incoming, response) => {
@@ -287,15 +305,29 @@ async function upstream(boot: 'legacy' | 'batched' | 'remote-settings' = 'legacy
       networkSocket.destroy()
       return
     }
-    networkSocket.write([
+    const responseLines = [
       'HTTP/1.1 101 Switching Protocols',
       'Upgrade: websocket',
       'Connection: Upgrade',
       `Sec-WebSocket-Accept: ${websocketAccept(key)}`,
       'Set-Cookie: upstream-secret=must-not-pass',
+      ...upgradeHeaderLines,
       '',
       '',
-    ].join('\r\n'))
+    ]
+    let response = Buffer.from(responseLines.join('\r\n'), 'latin1')
+    if (upgradeHeaderBytes !== undefined) {
+      const paddingOverhead = Buffer.byteLength('X-Padding: \r\n', 'latin1')
+      const paddingBytes = upgradeHeaderBytes - response.length - paddingOverhead
+      if (paddingBytes < 0) {
+        networkSocket.destroy(new Error('requested WebSocket response header is too small'))
+        return
+      }
+      responseLines.splice(-2, 0, `X-Padding: ${'x'.repeat(paddingBytes)}`)
+      response = Buffer.from(responseLines.join('\r\n'), 'latin1')
+    }
+    upgradeResponseBytes.push(response.length)
+    networkSocket.write(Buffer.concat([response, upgradeBurst]))
     networkSocket.pipe(networkSocket)
   })
   const port = await listen(server)
@@ -304,6 +336,7 @@ async function upstream(boot: 'legacy' | 'batched' | 'remote-settings' = 'legacy
     port,
     observations,
     upgradeObservations,
+    upgradeResponseBytes,
     releaseHold: () => { for (const release of held.splice(0)) release() },
   }
 }
@@ -369,9 +402,11 @@ async function openWebSocket(
   session: string,
   origin?: string,
   fetchSite: string | undefined = 'same-origin',
+  minimumRemainderBytes = 0,
 ): Promise<{
   socket: Socket
   response: string
+  remainder: Buffer
 }> {
   const address = instance.address()
   const key = Buffer.from('0123456789abcdef').toString('base64')
@@ -380,12 +415,18 @@ async function openWebSocket(
     let buffer = Buffer.alloc(0)
     const timeout = setTimeout(() => { socket.destroy(); reject(new Error('WebSocket handshake timed out')) }, 3_000)
     socket.once('error', reject)
+    socket.once('close', () => {
+      clearTimeout(timeout)
+      reject(new Error('WebSocket closed before handshake'))
+    })
     socket.on('data', (chunk: Buffer) => {
       buffer = Buffer.concat([buffer, chunk])
       const end = buffer.indexOf('\r\n\r\n')
       if (end < 0) return
+      const remainder = buffer.subarray(end + 4)
+      if (remainder.length < minimumRemainderBytes) return
       clearTimeout(timeout)
-      resolve({ socket, response: buffer.subarray(0, end).toString('latin1') })
+      resolve({ socket, response: buffer.subarray(0, end).toString('latin1'), remainder })
     })
     socket.once('connect', () => {
       socket.write([
@@ -1203,6 +1244,45 @@ describe('HTTP gateway', () => {
 })
 
 describe('WebSocket gateway', () => {
+  it('forwards a large first frame delivered with the upstream upgrade response', async () => {
+    const firstFrame = websocketBinaryFrame(Buffer.alloc(26 * 1024, 0x5a))
+    const inner = await upstream('legacy', false, firstFrame)
+    const instance = await gateway(inner.port)
+    const paired = await pair(instance)
+    const opened = await openWebSocket(
+      instance,
+      '/api/events.mux',
+      paired.session,
+      undefined,
+      undefined,
+      firstFrame.length,
+    )
+
+    expect(opened.response).toContain('101 Switching Protocols')
+    expect(opened.remainder).toEqual(firstFrame)
+    opened.socket.destroy()
+  })
+
+  it('accepts an upstream WebSocket response whose headers exactly meet the header limit', async () => {
+    const inner = await upstream('legacy', false, Buffer.alloc(0), [], 16 * 1024)
+    const instance = await gateway(inner.port)
+    const paired = await pair(instance)
+    const opened = await openWebSocket(instance, '/api/events.mux', paired.session)
+
+    expect(inner.upgradeResponseBytes).toEqual([16 * 1024])
+    expect(opened.response).toContain('101 Switching Protocols')
+    opened.socket.destroy()
+  })
+
+  it('rejects an upstream WebSocket response one byte beyond the header limit', async () => {
+    const inner = await upstream('legacy', false, Buffer.alloc(0), [], 16 * 1024 + 1)
+    const instance = await gateway(inner.port)
+    const paired = await pair(instance)
+
+    await expect(openWebSocket(instance, '/api/events.mux', paired.session)).rejects.toThrow()
+    expect(inner.upgradeResponseBytes).toEqual([16 * 1024 + 1])
+  })
+
   it('accepts an exact-origin Android WebView upgrade without Fetch Metadata', async () => {
     const inner = await upstream()
     const instance = await gateway(inner.port)


### PR DESCRIPTION
## Summary

- preserve the first WebSocket frame when it arrives with the upstream `101 Switching Protocols` response
- keep the 16 KiB response-header limit unchanged and cover its exact boundary
- prepare plugin and Android version 0.3.5 with bilingual release notes

## Validation

- `npm run verify`
- 287 tests passed, 2 skipped
- local DSH 0.1.2-alpha.2 runtime smoke test over the authenticated Web client and LAN gateway

Fixes #26.