### PR TITLE
fix: Windows Desktop subprocess output and release 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
+## 0.3.7 - 2026-09-02
+
+- Fix the Windows DSH Desktop startup failure reported in [#22](https://github.com/saya-ch/dsh-mobile/issues/22): capture subprocess output through the callback API instead of relying on `execFile` promisify metadata that a host wrapper may omit. Thanks @XChen446 for the precise 0.3.6 stack trace.
+- Apply the same output handling to Windows SID resolution, private-file ACLs, route selection, and firewall diagnostics/setup. Invalid SID output and ACL failures still reject the operation; a failed SID lookup can be retried and Windows permission commands have bounded execution time.
+- Retain the 0.3.6 removal of the exact DSH version allowlist. Existing 0.3.3-0.3.6 Android apps and paired devices remain compatible; the 0.3.7 APK updates version metadata only.
+
 ## 0.3.6 - 2026-09-02
 
 - Remove the fixed DeepSeek Harness version allowlist from plugin startup and npm peer metadata. A compatible future DSH release can now load without waiting for DSH Mobile to enumerate its exact prerelease version.

--- a/README.en.md
+++ b/README.en.md
@@ -19,14 +19,14 @@
 
 > DSH Mobile is a DeepSeek Harness community plugin; the native app supports Android only.
 >
-> **0.3.6 update**: remove the exact DSH version allowlist and verify compatibility with 0.1.2-alpha.3/alpha.4. Future releases with compatible interfaces are no longer blocked only because their version is new. [Details](CHANGELOG.md).
+> **0.3.7 update**: fix a Windows DSH Desktop startup crash when capturing system-command output, including the related route-selection and firewall-diagnostic paths. The 0.3.6 DSH version policy and private-file protections remain intact. [Details](CHANGELOG.md).
 >
-> **Upgrade reminder**: use Mobile plugin 0.3.6 or later with DSH 0.1.2-alpha.3/alpha.4. Existing 0.3.3-0.3.5 apps and pairings remain valid. [Compatibility notes](#compatibility).
+> **Upgrade reminder**: Windows DSH Desktop users should update to plugin 0.3.7. Existing 0.3.3-0.3.6 apps and paired devices remain compatible without re-pairing. [Compatibility notes](#compatibility).
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.6/dsh-mobile-android-v0.3.6.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.6/dsh-mobile-android-v0.3.6.apk"><strong>Download Android app 0.3.6</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.6">Release notes and checksums</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.7/dsh-mobile-android-v0.3.7.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.7/dsh-mobile-android-v0.3.7.apk"><strong>Download Android app 0.3.7</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.7">Release notes and checksums</a></sub>
 </p>
 
 DSH Mobile is a DeepSeek Harness plugin that lets a mobile browser or the Android app connect over a protected LAN or an optional Tailscale Funnel, cpolar, or self-hosted FRP remote path. Local and remote access keep the same sessions, Workspaces, messages, and tools while using separate switches and paired-device stores without modifying DeepSeek Harness source.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 > DSH Mobile 是 DeepSeek Harness 社区插件，原生 App 仅支持 Android。
 >
-> **0.3.6 更新**：取消 DSH 精确版本白名单，已验证兼容 0.1.2-alpha.3/alpha.4；今后接口兼容的新版本不会再仅因版本号而阻止插件启动。[详细记录](CHANGELOG.md)。
+> **0.3.7 更新**：修复 Windows DSH Desktop 获取系统命令输出时的启动崩溃，同步完善网卡选择与防火墙诊断；保留 0.3.6 的 DSH 版本开放策略和私有文件权限保护。[详细记录](CHANGELOG.md)。
 >
-> **升级提醒**：DSH 0.1.2-alpha.3/alpha.4 请使用 Mobile 插件 0.3.6 或更高版本；现有 0.3.3-0.3.5 App 与配对无需重建。[兼容说明](#兼容性)。
+> **升级提醒**：Windows DSH Desktop 用户请更新至插件 0.3.7；现有 0.3.3-0.3.6 App 可继续使用，无需重新配对。[兼容说明](#兼容性)。
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.6/dsh-mobile-android-v0.3.6.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.6/dsh-mobile-android-v0.3.6.apk"><strong>下载 Android App 0.3.6</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.6">版本说明与校验文件</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.7/dsh-mobile-android-v0.3.7.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.7/dsh-mobile-android-v0.3.7.apk"><strong>下载 Android App 0.3.7</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.7">版本说明与校验文件</a></sub>
 </p>
 
 DSH Mobile 是一个 DeepSeek Harness 插件，让手机浏览器或 Android App 通过局域网，或可选的 Tailscale Funnel、cpolar、自建 FRP 远程通道连接电脑，继续使用同一份会话、工作区、消息和工具。局域网与远程访问分别启停、分别管理设备，且都不修改 DeepSeek Harness 源码。

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "io.github.sayach.dshmobile"
         minSdk = 29
         targetSdk = 36
-        versionCode = 51
-        versionName = "0.3.6"
+        versionCode = 52
+        versionName = "0.3.7"
     }
 
     signingConfigs {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-mobile",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": false,
   "description": "DeepSeek Harness 移动端适配与安全访问插件，支持局域网、远程连接、Android App 和手机浏览器。",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-import { execFile as execFileCallback } from 'node:child_process'
+import { execFileText as execFile } from './exec-file.js'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { promisify } from 'node:util'
 import {
   ensureManagedCa,
   preferredLanInterfaceNames,
@@ -21,7 +20,6 @@ interface SetupOptions {
   readonly configureFirewall: boolean
 }
 
-const execFile = promisify(execFileCallback)
 const FIREWALL_TCP_RULE = 'DSH Mobile HTTPS'
 const FIREWALL_UDP_RULE = 'DSH Mobile Discovery'
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,10 +1,8 @@
-import { execFile as execFileCallback } from 'node:child_process'
+import { execFileText as execFile } from './exec-file.js'
 import { lookup } from 'node:dns/promises'
-import { promisify } from 'node:util'
 import type { RemoteProvider } from './remote.js'
 import { DSH_MOBILE_VERSION, MINIMUM_ANDROID_APP_VERSION } from './version.js'
 
-const execFile = promisify(execFileCallback)
 
 export type DiagnosticStatus = 'ok' | 'warning' | 'error' | 'info'
 export type DiagnosticReason =

--- a/src/exec-file.ts
+++ b/src/exec-file.ts
@@ -1,0 +1,19 @@
+import { execFile, type ExecFileOptions } from 'node:child_process'
+
+/** Capture both output streams even when a desktop host wraps execFile without Node's promisify metadata. */
+export function execFileText(
+  file: string,
+  args: readonly string[],
+  options: Omit<ExecFileOptions, 'encoding'> & { encoding?: 'utf8' } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(file, [...args], { windowsHide: true, ...options, encoding: 'utf8' }, (error, stdout, stderr) => {
+      if (error !== null) { reject(error); return }
+      if (typeof stdout !== 'string' || typeof stderr !== 'string') {
+        reject(new Error('subprocess returned invalid text output'))
+        return
+      }
+      resolve({ stdout, stderr })
+    })
+  })
+}

--- a/src/managed-setup.ts
+++ b/src/managed-setup.ts
@@ -3,11 +3,10 @@ import {
   createPrivateKey,
   createPublicKey,
 } from 'node:crypto'
-import { execFile as execFileCallback } from 'node:child_process'
+import { execFileText as execFile } from './exec-file.js'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { networkInterfaces, type NetworkInterfaceInfo } from 'node:os'
 import { basename, dirname, join } from 'node:path'
-import { promisify } from 'node:util'
 import { generate } from 'selfsigned'
 import { restrictPrivateFile } from './private-file.js'
 
@@ -36,7 +35,6 @@ export interface ManagedSetup {
 type InterfaceTable = NodeJS.Dict<NetworkInterfaceInfo[]>
 type RouteCommand = (file: string, args: readonly string[]) => Promise<string>
 
-const execFile = promisify(execFileCallback)
 const VIRTUAL_INTERFACE_MARKERS = [
   'bridge', 'docker', 'hyper-v', 'mihomo', 'radmin', 'tailscale', 'tap', 'tun',
   'utun', 'vbox', 'veth', 'virtual', 'vmware', 'vpn', 'vethernet', 'wsl', 'zerotier',

--- a/src/private-file.ts
+++ b/src/private-file.ts
@@ -1,18 +1,20 @@
-import { execFile as execFileCallback } from 'node:child_process'
 import { chmod } from 'node:fs/promises'
-import { promisify } from 'node:util'
+import { execFileText as execFile } from './exec-file.js'
 
-const execFile = promisify(execFileCallback)
 let userSidTask: Promise<string> | undefined
 
 async function currentWindowsUserSid(): Promise<string> {
   userSidTask ??= execFile('whoami.exe', ['/user', '/fo', 'csv', '/nh'], {
     encoding: 'utf8',
     windowsHide: true,
+    timeout: 10_000,
   }).then(({ stdout }) => {
     const match = /,"(S-\d(?:-\d+)+)"\s*$/u.exec(stdout.trim())
     if (match?.[1] === undefined) throw new Error('unable to resolve the current Windows user SID')
     return match[1]
+  }).catch((error: unknown) => {
+    userSidTask = undefined
+    throw error
   })
   return userSidTask
 }
@@ -33,5 +35,5 @@ export async function restrictPrivateFile(file: string, mode = 0o600): Promise<v
     '*S-1-1-0',
     '*S-1-5-11',
     '*S-1-5-32-545',
-  ], { encoding: 'utf8', windowsHide: true })
+  ], { encoding: 'utf8', windowsHide: true, timeout: 10_000 })
 }

--- a/tests/exec-file.test.ts
+++ b/tests/exec-file.test.ts
@@ -1,0 +1,37 @@
+import { promisify } from 'node:util'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({ stdout: 'hello\n' as unknown, stderr: '' as unknown, error: null as Error | null }))
+vi.mock('node:child_process', () => ({
+  // A desktop-style callback wrapper has no custom promisify metadata.
+  execFile: (_file: string, _args: string[], _options: unknown, callback: (error: Error | null, stdout: unknown, stderr: unknown) => void) => {
+    callback(state.error, state.stdout, state.stderr)
+  },
+}))
+import { execFile } from 'node:child_process'
+import { execFileText } from '../src/exec-file.js'
+
+afterEach(() => { state.stdout = 'hello\n'; state.stderr = ''; state.error = null })
+
+describe('desktop-compatible subprocess output', () => {
+  it('reproduces the lost stdout property with generic promisify', async () => {
+    const result = await promisify(execFile)('fixture', [], { encoding: 'utf8' })
+    expect(result).toBe('hello\n')
+    expect(result.stdout).toBeUndefined()
+  })
+
+  it('preserves both streams without relying on promisify metadata', async () => {
+    state.stderr = 'warning\n'
+    await expect(execFileText('fixture', [])).resolves.toEqual({ stdout: 'hello\n', stderr: 'warning\n' })
+  })
+
+  it('propagates command failures instead of accepting output', async () => {
+    state.error = new Error('permission denied')
+    await expect(execFileText('fixture', [])).rejects.toBe(state.error)
+  })
+
+  it('rejects missing output with an actionable error instead of a trim crash', async () => {
+    state.stdout = undefined
+    await expect(execFileText('fixture', [])).rejects.toThrow('subprocess returned invalid text output')
+  })
+})

--- a/tests/private-file-desktop.test.ts
+++ b/tests/private-file-desktop.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const commands = vi.hoisted(() => ({
+  exec: vi.fn(),
+  chmod: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('node:child_process', () => ({ execFile: commands.exec }))
+vi.mock('node:fs/promises', () => ({ chmod: commands.chmod }))
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.stubGlobal('process', { ...process, platform: 'win32' })
+  commands.exec.mockReset()
+  commands.chmod.mockClear()
+  commands.exec.mockImplementation((file, _args, _options, callback) => {
+    callback(null, file === 'whoami.exe' ? '"desktop\\user","S-1-5-21-123-456-789-1001"\r\n' : '', '')
+  })
+})
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('Windows private files under a desktop execFile wrapper', () => {
+  it('resolves a SID and still applies restrictive ACLs', async () => {
+    const { restrictPrivateFile } = await import('../src/private-file.js')
+    await restrictPrivateFile('fixture.json')
+    expect(commands.chmod).toHaveBeenCalledWith('fixture.json', 0o600)
+    expect(commands.exec).toHaveBeenLastCalledWith('icacls.exe', expect.arrayContaining([
+      'fixture.json', '/inheritance:r', '*S-1-5-21-123-456-789-1001:(F)', '/remove:g', '*S-1-1-0',
+    ]), expect.objectContaining({ timeout: 10_000, windowsHide: true }), expect.any(Function))
+    await restrictPrivateFile('second.json')
+    expect(commands.exec.mock.calls.filter(call => call[0] === 'whoami.exe')).toHaveLength(1)
+  })
+
+  it('rejects an invalid SID without running icacls and retries on the next request', async () => {
+    commands.exec.mockImplementationOnce((_file, _args, _options, callback) => callback(null, 'invalid SID', ''))
+    const { restrictPrivateFile } = await import('../src/private-file.js')
+    await expect(restrictPrivateFile('fixture.json')).rejects.toThrow('unable to resolve the current Windows user SID')
+    expect(commands.exec).toHaveBeenCalledTimes(1)
+    await expect(restrictPrivateFile('fixture.json')).resolves.toBeUndefined()
+    expect(commands.exec).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not report success when applying the ACL fails', async () => {
+    commands.exec.mockImplementation((file, _args, _options, callback) => {
+      callback(file === 'icacls.exe' ? new Error('ACL denied') : null, '"user","S-1-5-21-123"', '')
+    })
+    const { restrictPrivateFile } = await import('../src/private-file.js')
+    await expect(restrictPrivateFile('fixture.json')).rejects.toThrow('ACL denied')
+  })
+})


### PR DESCRIPTION
Resolve the Windows Desktop subprocess-output startup error reported in issue #22. Use explicit callback capture across SID/ACL, route selection and firewall commands. Preserve file protections, bound permission commands and retry failed SID lookups. Retain the 0.3.6 DSH version policy; release plugin/APK metadata 0.3.7.

Validation: npm run verify passed (285 tests passed, 2 skipped), including typecheck, build, package gates and native Windows ACL integration. Regression tests reproduce missing promisify metadata and cover output capture, invalid output, SID retry and ACL failures. The built bundle passed device save/load with restrictive Windows ACLs under a wrapped native execFile. DSH 0.1.2-alpha.4 contract and v0.3.7 tag gates passed. Desktop GUI E2E has not been performed. CI must pass before merge.

Refs #22. Keep the issue open for reporter confirmation.