### PR TITLE
patch: WeChat mini-program header compatibility (Sec-Fetch-Site / comma-joined Origin)

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -26,7 +26,7 @@
         initiallyEnabled: false
         listenHost: 127.0.0.1
         listenPort: 3443
-        upstreamOrigin: http://127.0.0.1:3080
+        upstreamOrigin: http://127.0.0.1:43120
         allowedCidrs: [127.0.0.0/8]
         tls:
           mode: disabled

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -157,8 +157,12 @@ export function assertExternalTrust(request: IncomingMessage, policy: RequestTru
   const origin = request.headers.origin
   if (origin !== undefined && !policy.acceptsOrigin(origin)) throw new HttpError(403, 'forbidden')
   const site = request.headers['sec-fetch-site']
-  if (site !== undefined && site !== 'same-origin' && site !== 'none') throw new HttpError(403, 'forbidden')
-  if (requireOrigin && (!policy.acceptsOrigin(origin) || site !== 'same-origin')) throw new HttpError(403, 'forbidden')
+  // 微信小程序（wx.request / wx.connectSocket）的 Sec-Fetch-Site 由微信自动附加
+  // （same-origin / same-site / cross-site），客户端无法控制，也不代表真实跨站攻击；
+  // CSRF 防护的核心是下方对 Origin 的强制校验，因此这里接受全部合法取值。
+  if (site !== undefined && site !== 'same-origin' && site !== 'same-site' && site !== 'cross-site' && site !== 'none') throw new HttpError(403, 'forbidden')
+  // POST 只强制 Origin 正确。
+  if (requireOrigin && !policy.acceptsOrigin(origin)) throw new HttpError(403, 'forbidden')
 }
 
 function localAuthority(header: string | undefined): { hostname: string; authority: string } | undefined {

--- a/src/network.ts
+++ b/src/network.ts
@@ -200,16 +200,20 @@ export class RequestTrustPolicy {
   /** Return the canonical accepted Origin, otherwise undefined. */
   canonicalOrigin(header: string | undefined): string | undefined {
     if (header === undefined) return undefined
-    let normalized: string
-    try {
-      const parsed = new URL(header)
-      if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '' || parsed.username !== '' || parsed.password !== '') {
-        return undefined
+    // 微信小程序 wx.connectSocket 会把多个 Origin 值用逗号合并（如 "http://host,undefined"），逐个尝试。
+    for (const part of header.split(',')) {
+      let normalized: string
+      try {
+        const parsed = new URL(part.trim())
+        if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '' || parsed.username !== '' || parsed.password !== '') {
+          continue
+        }
+        normalized = parsed.origin.toLowerCase()
+      } catch {
+        continue
       }
-      normalized = parsed.origin.toLowerCase()
-    } catch {
-      return undefined
+      if (this.origins.has(normalized)) return normalized
     }
-    return this.origins.has(normalized) ? normalized : undefined
+    return undefined
   }
 }


### PR DESCRIPTION
## Why

A native WeChat Mini-Program client cannot control several headers its network APIs attach automatically:

- `wx.request` sends `Sec-Fetch-Site: same-site` on LAN and `cross-site` over a remote HTTPS tunnel
- `wx.connectSocket` (WebSocket) merges multiple `Origin` values with commas (e.g. `http://host,undefined`)

With the current checks the gateway answers 403 to these legitimate mobile clients.
This PR relaxes the two checks **without weakening CSRF protection**.

## Changes

1. **src/http-security.ts — `assertExternalTrust`**
   Accept `same-site` and `cross-site` as valid `Sec-Fetch-Site` values (previously only `same-origin`/`none`).
   The `requireOrigin` branch now enforces the mandatory `Origin` allow-list check alone — that stays the
   real CSRF control; `Sec-Fetch-Site` is kept only as a format guard rejecting unknown values.

2. **src/network.ts — `RequestTrustPolicy.canonicalOrigin`**
   Split the `Origin` header on commas and test each part, tolerating the comma-joined value produced by
   `wx.connectSocket`. Non-URL fragments (like `undefined`) are skipped.

3. **cordis.patch.yml — `upstreamOrigin`**
   Points `upstreamOrigin` to the DSH Desktop WebServer port (43120). Note this value is environment-specific:
   it is set for running the mobile gateway under **DSH Desktop 2.x** (whose WebServer listens on 43120).
   On setups where the desktop serves on 3080 keep the original value.

## Verification

- Tested against dsh-mobile 0.3.6 + DSH Desktop 2.0.4 with a real WeChat DevTools client over LAN and remote tunnel.
- Native pairing, session list, streaming chat, ask/approval round-trips all work after these changes.
