### PR TITLE
fix: follow up WeChat compatibility safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
+## Unreleased
+
+- Preserve the WeChat Mini-Program compatibility changes contributed in PR #34 by @StrawberryAO while deriving an unset upstream from the active DSH WebServer port. Standalone Web defaults, Desktop's configured port, and Desktop's bind-conflict retry port therefore use the same proxy target.
+- Accept the observed `allowed-origin,undefined` WebSocket Origin form while rejecting mixed values that include an untrusted Origin.
+
 ## 0.3.7 - 2026-09-02
 
-- Fix the Windows DSH Desktop startup failure reported in [#22](https://github.com/saya-ch/dsh-mobile/issues/22): capture subprocess output through the callback API instead of relying on `execFile` promisify metadata that a host wrapper may omit. Thanks @XChen446 for the precise 0.3.6 stack trace.
+- Fix the Windows DSH Desktop startup failure reported in [#22#22](https://github.com/saya-ch/dsh-mobile/issues/22): capture subprocess output through the callback API instead of relying on `execFile` promisify metadata that a host wrapper may omit. Thanks @XChen446 for the precise 0.3.6 stack trace.
 - Apply the same output handling to Windows SID resolution, private-file ACLs, route selection, and firewall diagnostics/setup. Invalid SID output and ACL failures still reject the operation; a failed SID lookup can be retried and Windows permission commands have bounded execution time.
 - Retain the 0.3.6 removal of the exact DSH version allowlist. Existing 0.3.3-0.3.6 Android apps and paired devices remain compatible; the 0.3.7 APK updates version metadata only.
 
@@ -16,7 +21,7 @@ Notable changes to DSH Mobile are recorded here. GitHub Releases remain the sour
 
 ## 0.3.5 - 2026-09-01
 
-- Fix [#26](https://github.com/saya-ch/dsh-mobile/issues/26): prevent mobile startup from remaining on “Loading plugins” over LAN or remote access when DSH sends the WebSocket upgrade response and initial snapshot together. The gateway now preserves that snapshot without relaxing its 16 KiB response-header limit. Thanks @oliverwan97 for the detailed report.
+- Fix [#26#26](https://github.com/saya-ch/dsh-mobile/issues/26): prevent mobile startup from remaining on “Loading plugins” over LAN or remote access when DSH sends the WebSocket upgrade response and initial snapshot together. The gateway now preserves that snapshot without relaxing its 16 KiB response-header limit. Thanks @oliverwan97 for the detailed report.
 
 ## 0.3.4 - 2026-08-31
 
@@ -39,7 +44,7 @@ Notable changes to DSH Mobile are recorded here. GitHub Releases remain the sour
 
 ## 0.3.2 - 2026-08-29
 
-- Special thanks to @JackRushante for [#16](https://github.com/saya-ch/dsh-mobile/pull/16): the secure Android media bridge, image attachments, localization foundation, bounded extension requests, and Funnel lifecycle hardening. This release retains all four original commits and their author metadata.
+- Special thanks to @JackRushante for [#16#16](https://github.com/saya-ch/dsh-mobile/pull/16): the secure Android media bridge, image attachments, localization foundation, bounded extension requests, and Funnel lifecycle hardening. This release retains all four original commits and their author metadata.
 - Move image selection and camera capture into a dedicated top row of the composer command menu, without focusing the message editor.
 - Push extension and `/mobile` changes to authenticated phones immediately, while retaining bounded polling as a network-recovery fallback.
 - Bind each mobile UI to its matching Host, script, style, and asset generation; retain the previous Host through a bounded refresh window, fail closed on client activation errors, and tighten scoped requests against encoded path traversal.
@@ -49,7 +54,7 @@ Notable changes to DSH Mobile are recorded here. GitHub Releases remain the sour
 
 ## 0.3.1 - 2026-08-28
 
-- Credit @BlueandwhiteXD ([#15](https://github.com/saya-ch/dsh-mobile/pull/15)) for the Android keyboard inset report and fix incorporated into the 0.3 mobile layout.
+- Credit @BlueandwhiteXD ([#15#15](https://github.com/saya-ch/dsh-mobile/pull/15)) for the Android keyboard inset report and fix incorporated into the 0.3 mobile layout.
 
 ## 0.3.0 - 2026-08-28
 

--- a/README.en.md
+++ b/README.en.md
@@ -208,7 +208,7 @@ DSH Mobile 0.3.6 no longer blocks startup by exact DSH version and has verified 
 
 The plugin no longer uses a runtime version allowlist. CI continuously checks the frontend, connection, and trust interfaces used from the DSH main branch, so adaptation is required only when those interfaces actually change. If a future DSH update causes a real display or connection failure, update DSH Mobile and include diagnostics in the report.
 
-0.3.4 fixes duplicate directory-picker registration in Windows [DSH Desktop](https://github.com/anywhere-labs/dsh-desktop). It reuses the desktop host's in-page directory browser; standalone Web launches still let phones select workspaces on the computer. Mobile access through Desktop requires compatibility mode and browser access enabled, with Mobile's upstream address matching Desktop's listening port.
+0.3.4 fixes duplicate directory-picker registration in Windows [DSH Desktop](https://github.com/anywhere-labs/dsh-desktop). It reuses the desktop host's in-page directory browser; standalone Web launches still let phones select workspaces on the computer. Mobile access through Desktop requires compatibility mode and browser access enabled. When no setup file specifies an upstream, the gateway follows the active DSH WebServer's actual port; a managed setup continues to use the `--dsh-port` value written by `dsh-mobile setup`.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ DSH Mobile 0.3.6 不再按 DSH 精确版本号阻止启动，并已验证 DSH 0.
 
 插件不再使用运行时版本白名单；CI 会持续检查 DSH 主分支真实使用的前端、连接与信任接口，只有接口变化才需要适配。未来 DSH 更新若出现实际显示或连接异常，请升级 DSH Mobile 并提交诊断信息。
 
-0.3.4 修复 Windows [DSH Desktop](https://github.com/anywhere-labs/dsh-desktop) 的目录选择器重复注册问题：复用桌面宿主的页面内目录浏览器，普通 Web 启动仍保留手机选择电脑工作区的能力。Desktop 连接手机时需使用兼容模式并启用浏览器访问，Mobile 的上游地址应与 Desktop 的监听端口一致。
+0.3.4 修复 Windows [DSH Desktop](https://github.com/anywhere-labs/dsh-desktop) 的目录选择器重复注册问题：复用桌面宿主的页面内目录浏览器，普通 Web 启动仍保留手机选择电脑工作区的能力。Desktop 连接手机时需使用兼容模式并启用浏览器访问。未在 setup 文件中指定 upstream 时，网关会跟随当前 DSH WebServer 的实际端口；managed setup 则继续使用 `dsh-mobile setup` 写入的 `--dsh-port`。
 
 ## 卸载
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -26,7 +26,6 @@
         initiallyEnabled: false
         listenHost: 127.0.0.1
         listenPort: 3443
-        upstreamOrigin: http://127.0.0.1:43120
         allowedCidrs: [127.0.0.0/8]
         tls:
           mode: disabled

--- a/src/network.ts
+++ b/src/network.ts
@@ -200,20 +200,24 @@ export class RequestTrustPolicy {
   /** Return the canonical accepted Origin, otherwise undefined. */
   canonicalOrigin(header: string | undefined): string | undefined {
     if (header === undefined) return undefined
-    // 微信小程序 wx.connectSocket 会把多个 Origin 值用逗号合并（如 "http://host,undefined"），逐个尝试。
+    // 微信小程序 wx.connectSocket 会把允许的 Origin 与 undefined 用逗号合并。
+    let normalized: string | undefined
     for (const part of header.split(',')) {
-      let normalized: string
+      const trimmed = part.trim()
+      if (trimmed === 'undefined') continue
+      let candidate: string
       try {
-        const parsed = new URL(part.trim())
+        const parsed = new URL(trimmed)
         if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '' || parsed.username !== '' || parsed.password !== '') {
-          continue
+          return undefined
         }
-        normalized = parsed.origin.toLowerCase()
+        candidate = parsed.origin.toLowerCase()
       } catch {
-        continue
+        return undefined
       }
-      if (this.origins.has(normalized)) return normalized
+      if (!this.origins.has(candidate) || normalized !== undefined) return undefined
+      normalized = candidate
     }
-    return undefined
+    return normalized
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -174,13 +174,13 @@ async function loadSetup(config: PluginConfig): Promise<LoadedSetup> {
   }
 }
 
-function loopbackTemplate(loaded: LoadedSetup): ResolvedGatewayConfig {
+function loopbackTemplate(loaded: LoadedSetup, webServerPort: number): ResolvedGatewayConfig {
   const base = withoutSetupKeys(loaded.config)
   return parseGatewayConfig({
     ...base,
     ...(loaded.kind === 'managed'
       ? { upstreamOrigin: loaded.setup.upstreamOrigin }
-      : loaded.config.upstreamOrigin === undefined ? {} : { upstreamOrigin: loaded.config.upstreamOrigin }),
+      : { upstreamOrigin: loaded.config.upstreamOrigin ?? `http://127.0.0.1:${String(webServerPort)}` }),
     listenHost: '127.0.0.1',
     listenPort: 0,
     publicAuthorities: ['127.0.0.1'],
@@ -268,7 +268,7 @@ export async function apply(ctx: Context, config: PluginConfig): Promise<void> {
   const dshVersion = installedDshVersion()
   const loaded = await loadSetup(config)
   const mobileAccess: MobileAccessService = createMobileAccessService(ctx)
-  const template = loopbackTemplate(loaded)
+  const template = loopbackTemplate(loaded, ctx.webServer.port)
   const upstreamLoginUrl = upstreamAuthenticatedUrl(ctx, template.upstreamOrigin)
   const instanceId = await stableInstanceId(loaded, template)
   const stateDirectory = dirname(template.stateFile)

--- a/tests/config-network.test.ts
+++ b/tests/config-network.test.ts
@@ -266,6 +266,9 @@ describe('network trust policy', () => {
     expect(policy.acceptsOrigin('https://harness.example:3443')).toBe(true)
     expect(policy.acceptsOrigin('http://harness.example:3443')).toBe(false)
     expect(policy.acceptsOrigin('https://harness.example:3443/path')).toBe(false)
+    expect(policy.acceptsOrigin('https://harness.example:3443,undefined')).toBe(true)
+    expect(policy.acceptsOrigin('https://harness.example:3443,https://evil.example')).toBe(false)
+    expect(policy.acceptsOrigin('https://evil.example,https://harness.example:3443')).toBe(false)
   })
 
   it.each([

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -57,14 +57,16 @@ async function invoke(route: WebRoute, method: 'GET' | 'POST', path: string, bod
   }
 }
 
-async function mount(initiallyEnabled = false): Promise<{ context: Context; route: WebRoute; command: CommandDefinition }> {
+async function mount(initiallyEnabled = false, webServerPort = 3080): Promise<{ context: Context; route: WebRoute; command: CommandDefinition; upstreamBase: string | undefined }> {
   const directory = await mkdtemp(join(tmpdir(), 'dsh-mobile-plugin-'))
   temporaryDirectories.push(directory)
   let route: WebRoute | undefined
   let command: CommandDefinition | undefined
+  let upstreamBase: string | undefined
   const context = new Context()
   contexts.push(context)
   context.provide('webServer', {
+    port: webServerPort,
     register(candidate: WebRoute) {
       route = candidate
       return () => { if (route === candidate) route = undefined }
@@ -78,6 +80,7 @@ async function mount(initiallyEnabled = false): Promise<{ context: Context; rout
   } as never)
   context.provide('connection', {
     authenticatedUrl(baseUrl: string) {
+      upstreamBase = baseUrl
       return `${baseUrl}/?token=test-launch-token`
     },
   } as never)
@@ -92,7 +95,7 @@ async function mount(initiallyEnabled = false): Promise<{ context: Context; rout
   })
   if (route === undefined) throw new Error('plugin did not register its control route')
   if (command === undefined) throw new Error('plugin did not register its /mobile command')
-  return { context, route, command }
+  return { context, route, command, upstreamBase }
 }
 
 describe('remote Funnel gateway configuration', () => {
@@ -209,6 +212,11 @@ describe('stock DSH lifecycle', () => {
       checks: expect.any(Array),
       report: expect.stringContaining('DSH Mobile 诊断报告'),
     })
+  })
+
+  it('follows the active WebServer port when no setup upstream is configured', async () => {
+    const mounted = await mount(false, 43120)
+    expect(mounted.upstreamBase).toBe('http://127.0.0.1:43120')
   })
 
   it('starts and stops the gateway through the local control route', async () => {


### PR DESCRIPTION
Follow-up maintenance for merged PR #34 (WeChat Mini-Program compatibility).

- Preserve PR #34's Sec-Fetch-Site compatibility and comma-joined Origin support.
- Derive an unset upstream from the active DSH WebServer port instead of hard-coding Desktop's default 43120 in the shared bundle.
- Accept the observed allowed-origin,undefined form while rejecting mixed untrusted Origin values.
- Add focused regression tests and document standalone Web/Desktop port behavior.

PR #34 remains the contributor's original change and is already merged; this follow-up preserves that history and integrates the safety fixes.