### PR TITLE
docs:suggest adding community WeChat Mini-Program client (unofficial)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -164,6 +164,10 @@ The examples above, applied:
 
 The Android app is a thin Kotlin WebView shell and contains no frontend copy; mobile browsers load the same page. For compatibility diagnosis, append `?frontend=stock` to the browser URL to temporarily use the previous desktop-page adaptation.
 
+> **Community client (unofficial)**: [WeChat Mini-Program client](https://github.com/StrawberryAO/dsh-mobile-minapp)
+> A native WeChat Mini-Program that reuses the Mobile Access pairing and Remote stream protocol (requires dsh-mobile ≥ 0.3.8).
+> Because WeChat release builds enforce a domain allow-list (ICP-registered HTTPS origins only), it currently works via WeChat DevTools / real-device debugging; see its README.
+
 ## How it works
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Tailscale Funnel 覆盖范围广，但在中国大陆网络下可能不稳定。
 
 Android App 只是 Kotlin WebView 薄壳，不内置另一份网页；手机浏览器访问的是同一页面。需要排查兼容性时，可在浏览器地址后追加 `?frontend=stock`，临时回到旧的桌面页面适配模式。
 
+> **社区客户端（非官方）**：[微信小程序客户端](https://github.com/StrawberryAO/dsh-mobile-minapp)
+> 原生微信小程序实现，复用「移动访问」的配对与 Remote 流协议（需 dsh-mobile ≥ 0.3.8）。
+> 因微信正式版强制「合法域名」（需 ICP 备案的自有 HTTPS 域名），目前需通过微信开发者工具 / 真机调试使用，详见其 README。
+
 ## 工作原理
 
 ```mermaid


### PR DESCRIPTION
## Summary

Adds a link to a open source third-party (unofficial) WeChat Mini-Program client in the "App or mobile browser" section, so users looking for other mobile clients can discover it. The Mini-Program reuses the Mobile Access pairing and Remote stream protocol and works with dsh-mobile >= 0.3.8 (the WeChat compatibility fixes merged via #34 / #35). Because WeChat release builds enforce a domain allow-list (ICP-registered HTTPS origins only), it currently runs via WeChat DevTools / real-device debugging; the linked README documents usage and limits.

No code changes.

---

## 摘要

在「App 与手机浏览器」章节补充一个开源第三方（非官方）微信小程序客户端的链接，方便需要其他手机客户端的用户找到它。
该小程序复用「移动访问」的配对与 Remote 流协议，兼容 dsh-mobile ≥ 0.3.8（#34 / #35 已合入的微信兼容修复）。
由于微信正式版强制「合法域名」（需 ICP 备案的自有 HTTPS 域名），目前需通过微信开发者工具 / 真机调试使用，其 README 已说明用法与限制。

无代码改动。