### PR TITLE
release: prepare dsh-mobile 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
 
-## Unreleased
+## 0.3.10 - 2026-09-07
 
-- Keep the workspace sidebar open on desktop-sized viewports (≥900px): the dedicated layout docks it as a persistent panel that survives reconnects and no longer auto-closes after selecting a session, and the dimming scrim only covers the narrow overlay drawer and details panel. Narrow screens keep the overlay drawer behavior unchanged.
+- Keep the workspace sidebar open on desktop-sized viewports (≥900px): the dedicated layout docks it as a persistent panel that survives reconnects and no longer auto-closes after selecting a session, and the dimming scrim only covers the narrow overlay drawer and details panel. Narrow screens keep the overlay drawer behavior unchanged (thanks @idoall for reporting #42).
+- Declare storefront screenshots (`screenshots.json`) so plugin markets show a curated order: repository hero, LAN pairing, remote access, and two mobile UI shots.
+- Verify the mobile frontend, connection, and trust contracts against DeepSeek Harness 0.1.3-alpha.1 through the existing upstream-source CI gate; no compatibility code change was required.
 
 ## 0.3.9 - 2026-09-04
 

--- a/README.en.md
+++ b/README.en.md
@@ -19,14 +19,14 @@
 
 > DSH Mobile is a DeepSeek Harness community plugin; the native app supports Android only.
 >
-> **0.3.9 update**: thanks to @qzyqmzn for one-click VPS deployment of self-hosted FRP — fill in SSH details in the panel and frps, Caddy, and certificates install automatically; `/mobile` customization now reads the current mobile state before editing and self-checks afterwards; DeepSeek Harness 0.1.3-alpha.1 is supported. [Details](CHANGELOG.md).
+> **0.3.10 update**: thanks to @idoall for reporting — on wide viewports (≥900px) the session sidebar now stays open until explicitly collapsed; plugin-market storefront screenshots are declared. [Details](CHANGELOG.md).
 >
-> **Upgrade reminder**: Windows DSH Desktop users should update to plugin 0.3.9. Existing 0.3.3-0.3.8 apps and paired devices remain compatible without re-pairing. [Compatibility notes](#compatibility).
+> **Upgrade reminder**: Windows DSH Desktop users should update to plugin 0.3.10. Existing 0.3.3-0.3.9 apps and paired devices remain compatible without re-pairing. [Compatibility notes](#compatibility).
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.9/dsh-mobile-android-v0.3.9.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.9/dsh-mobile-android-v0.3.9.apk"><strong>Download Android app 0.3.9</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.9">Release notes and checksums</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.10/dsh-mobile-android-v0.3.10.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.10/dsh-mobile-android-v0.3.10.apk"><strong>Download Android app 0.3.10</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.10">Release notes and checksums</a></sub>
 </p>
 
 DSH Mobile is a DeepSeek Harness plugin that lets a mobile browser or the Android app connect over a protected LAN or an optional Tailscale Funnel, cpolar, or self-hosted FRP remote path. Local and remote access keep the same sessions, Workspaces, messages, and tools while using separate switches and paired-device stores without modifying DeepSeek Harness source.
@@ -198,13 +198,14 @@ The table below lists, for each plugin version, the DeepSeek Harness version it 
 
 | DSH Mobile plugin | Verified DeepSeek Harness version |
 | --- | --- |
+| `0.3.10` | `0.1.3-alpha.1` |
 | `0.3.9` | `0.1.3-alpha.1` |
 | `0.3.6`-`0.3.8` | `0.1.2-rc.1` |
 | `0.3.4`, `0.3.5` | `0.1.2-alpha.2` |
 | `0.3.0`-`0.3.3` | `0.1.2-alpha.1` |
 | `0.1.4`, `0.2.x` | `0.1.1-rc.2` |
 
-Existing 0.3.3-0.3.8 apps do not need re-pairing. Earlier apps use a different status-bar strategy, so updating both is recommended. App 0.1.3 or earlier requires reinstalling and pairing again.
+Existing 0.3.3-0.3.9 apps do not need re-pairing. Earlier apps use a different status-bar strategy, so updating both is recommended. App 0.1.3 or earlier requires reinstalling and pairing again.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 > DSH Mobile 是 DeepSeek Harness 社区插件，原生 App 仅支持 Android。
 >
-> **0.3.9 更新**：感谢 @qzyqmzn 贡献自建 FRP 的 VPS 一键部署，在控制面板填写 SSH 信息即可自动安装 frps、Caddy 与证书；`/mobile` 定制不再盲改，会先读取手机端现状并自检；同时支持 DeepSeek Harness 0.1.3-alpha.1。[详细记录](CHANGELOG.md)。
+> **0.3.10 更新**：感谢 @idoall 反馈，大屏（≥900px）会话侧边栏不再自动收起，常驻显示直到手动关闭；同时声明插件市场展示截图。[详细记录](CHANGELOG.md)。
 >
-> **升级提醒**：Windows DSH Desktop 用户请更新至插件 0.3.9；现有 0.3.3-0.3.8 App 可继续使用，无需重新配对。[兼容说明](#兼容性)。
+> **升级提醒**：Windows DSH Desktop 用户请更新至插件 0.3.10；现有 0.3.3-0.3.9 App 可继续使用，无需重新配对。[兼容说明](#兼容性)。
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.9/dsh-mobile-android-v0.3.9.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.9/dsh-mobile-android-v0.3.9.apk"><strong>下载 Android App 0.3.9</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.9">版本说明与校验文件</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.10/dsh-mobile-android-v0.3.10.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.10/dsh-mobile-android-v0.3.10.apk"><strong>下载 Android App 0.3.10</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.10">版本说明与校验文件</a></sub>
 </p>
 
 DSH Mobile 是一个 DeepSeek Harness 插件，让手机浏览器或 Android App 通过局域网，或可选的 Tailscale Funnel、cpolar、自建 FRP 远程通道连接电脑，继续使用同一份会话、工作区、消息和工具。局域网与远程访问分别启停、分别管理设备，且都不修改 DeepSeek Harness 源码。
@@ -207,13 +207,14 @@ flowchart LR
 
 | DSH Mobile 插件 | 验证支持的 DeepSeek Harness 版本 |
 | --- | --- |
+| `0.3.10` | `0.1.3-alpha.1` |
 | `0.3.9` | `0.1.3-alpha.1` |
 | `0.3.6`-`0.3.8` | `0.1.2-rc.1` |
 | `0.3.4`、`0.3.5` | `0.1.2-alpha.2` |
 | `0.3.0`-`0.3.3` | `0.1.2-alpha.1` |
 | `0.1.4`、`0.2.x` | `0.1.1-rc.2` |
 
-现有 0.3.3-0.3.8 App 无需重新配对；更早的 App 使用不同的状态栏策略，建议同步升级；App 0.1.3 及更早版本需卸载重装并重新配对。
+现有 0.3.3-0.3.9 App 无需重新配对；更早的 App 使用不同的状态栏策略，建议同步升级；App 0.1.3 及更早版本需卸载重装并重新配对。
 
 ## 卸载
 

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "io.github.sayach.dshmobile"
         minSdk = 29
         targetSdk = 36
-        versionCode = 54
-        versionName = "0.3.9"
+        versionCode = 55
+        versionName = "0.3.10"
     }
 
     signingConfigs {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-mobile",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": false,
   "description": "DeepSeek Harness 移动端适配与安全访问插件，支持局域网、远程连接、Android App 和手机浏览器。",
   "type": "module",


### PR DESCRIPTION
0.3.10 发版准备：宽屏侧边栏常驻（#42）、市场截图声明、0.1.3-alpha.1 契约验证。版本号 0.3.10（Android code 55），双语 README + CHANGELOG 同步，verify 与 Android 门禁本地全绿。