### PR TITLE
fix: sync the browser tab title with the current session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
 
+## Unreleased
+
+- Sync the browser tab title with the current session on the dedicated layout, matching the stock behavior (thanks @idoall for reporting #45).
+
 ## 0.3.10 - 2026-09-07
 
 - Keep the workspace sidebar open on desktop-sized viewports (≥900px): the dedicated layout docks it as a persistent panel that survives reconnects and no longer auto-closes after selecting a session, and the dimming scrim only covers the narrow overlay drawer and details panel. Narrow screens keep the overlay drawer behavior unchanged (thanks @idoall for reporting #42).

--- a/src/mobile-layout.ts
+++ b/src/mobile-layout.ts
@@ -7,7 +7,7 @@ export type { MobileLayoutLanguage } from './mobile-layout-messages.js'
 
 interface SessionState {
   readonly current?: string
-  readonly byId: Readonly<Record<string, { readonly blank?: boolean } | undefined>>
+  readonly byId: Readonly<Record<string, { readonly blank?: boolean; readonly title?: string } | undefined>>
 }
 
 interface MobileRootProps {
@@ -217,6 +217,17 @@ function MobileAppFrame(props: MobileRootProps & { readonly controller: MobileLa
   useEffect(() => {
     if (!hasSession) props.controller.closeDetails()
   }, [hasSession, props.controller])
+
+  // Mirror the stock layout: project the current session title into the
+  // browser tab, restoring the product title when no session is selected.
+  const sessionTitle = props.useSessions(session =>
+    session.current === undefined ? undefined : session.byId[session.current]?.title,
+  )
+  useEffect(() => {
+    const productTitle = document.title
+    if (sessionTitle !== undefined) document.title = `${sessionTitle} — ${productTitle}`
+    return () => { document.title = productTitle }
+  }, [sessionTitle])
 
   useEffect(() => {
     const suppressAutofocus = (event: FocusEvent): void => {

--- a/tests/mobile-layout.test.ts
+++ b/tests/mobile-layout.test.ts
@@ -334,6 +334,13 @@ describe('dedicated mobile layout boot', () => {
     expect(source).toContain('state.detailsOpen || (state.sidebarOpen && !wideViewport)')
   })
 
+  it('projects the current session title into the browser tab like the stock layout', () => {
+    const source = readFileSync(new URL('../src/mobile-layout.ts', import.meta.url), 'utf8')
+    expect(source).toContain('session.byId[session.current]?.title')
+    expect(source).toContain('document.title = `${sessionTitle} — ${productTitle}`')
+    expect(source).toContain('return () => { document.title = productTitle }')
+  })
+
   it('opens the command menu without restoring focus to the mobile editor', () => {
     const source = readFileSync(new URL('../src/mobile-layout.ts', import.meta.url), 'utf8')
     expect(source).toContain("event.target.closest('button[aria-haspopup=\"listbox\"]')")


### PR DESCRIPTION
远程页标签页标题跟随当前会话（与本机 stock 行为一致：`标题 — 产品名`，无会话时恢复产品名）。单测 24 过 + 真机 LAN 验证（切换会话标题实时跟随）。Fixes #45.