### PR TITLE
fix: render both right-seat names (0.3.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
 
+## 0.3.14 - 2026-09-08
+
+- Fixed a regression in 0.3.13: its layout adaptation tracked the harness master branch (which renamed the right details seat to `rightbar`), but the published 0.1.3-alpha.2 host still exposes `details` — so on real hosts the mobile right panel rendered empty. The layout now registers and renders both seat names (`details` with the legacy empty owner share, `rightbar` with resolved column geometry), so the right panel works on 0.1.3-alpha.1, the published 0.1.3-alpha.2, and the master contract alike. The compatibility check still asserts the master (`rightbar`) contract.
+
 ## 0.3.13 - 2026-09-08
 
 - Third-party WebSocket approval is interception-driven and generic: whenever a plugin's WebSocket connection is blocked, the diagnostics view groups the rejected paths by directory with attempt counts and offers per-path or allow-all approval, behind the same local-admin trust as pairing, and both the sidebar entry and the in-panel diagnostics button carry a red badge until reviewed. Manual path entry is tucked under an “advanced” disclosure that most users never need to open (thanks @idoall for reporting #47). Badge changes are announced to screen readers and the disclosure has a visible focus ring.

--- a/README.en.md
+++ b/README.en.md
@@ -19,14 +19,14 @@
 
 > DSH Mobile is a DeepSeek Harness community plugin; the native app supports Android only.
 >
-> **0.3.13 update**: interception-driven, plugin-agnostic WebSocket approval — grouped blocked paths, dual red badges, manual entry under an advanced disclosure (#47) — plus panel polish (FRP step numbering, deploy-notes layout, approval button) and adaptation to DeepSeek Harness 0.1.3-alpha.2 (layout right-bar slot rename). [Details](CHANGELOG.md).
+> **0.3.14 update**: a 0.3.13 layout regression is fixed — the mobile right panel (details) now adapts to both the published 0.1.3-alpha.2 and the newer development contract, rendering on either host. Everything 0.3.13 brought stays (interception-driven WebSocket approval #47, panel polish, screen-reader announcements). [Details](CHANGELOG.md).
 >
-> **Upgrade reminder**: check your desktop DeepSeek Harness version before updating the plugin — **0.1.3-alpha.2 or later** pairs with plugin **0.3.13**; on an earlier desktop (0.1.2 line or 0.1.3-alpha.1) stay on plugin **0.3.12**. Existing 0.3.3-0.3.12 apps and paired devices remain compatible without re-pairing. [Compatibility notes](#compatibility).
+> **Upgrade reminder**: plugin **0.3.14** is recommended and works on every 0.1.3 desktop release (alpha.1 included). Restart DSH after installing a new plugin. Existing 0.3.3-0.3.13 apps and paired devices remain compatible without re-pairing. [Compatibility notes](#compatibility).
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.13/dsh-mobile-android-v0.3.13.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.13/dsh-mobile-android-v0.3.13.apk"><strong>Download Android app 0.3.13</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.13">Release notes and checksums</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.14/dsh-mobile-android-v0.3.14.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.14/dsh-mobile-android-v0.3.14.apk"><strong>Download Android app 0.3.14</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.14">Release notes and checksums</a></sub>
 </p>
 
 DSH Mobile is a DeepSeek Harness plugin that lets a mobile browser or the Android app connect over a protected LAN or an optional Tailscale Funnel, cpolar, or self-hosted FRP remote path. Local and remote access keep the same sessions, Workspaces, messages, and tools while using separate switches and paired-device stores without modifying DeepSeek Harness source.
@@ -201,14 +201,14 @@ The table below lists, for each plugin version, the DeepSeek Harness version it 
 
 | DSH Mobile plugin | Verified DeepSeek Harness version |
 | --- | --- |
-| `0.3.13` | `0.1.3-alpha.2` |
+| `0.3.14` | `0.1.3-alpha.2` |
 | `0.3.9`-`0.3.12` | `0.1.3-alpha.1` |
 | `0.3.6`-`0.3.8` | `0.1.2-rc.1` |
 | `0.3.4`, `0.3.5` | `0.1.2-alpha.2` |
 | `0.3.0`-`0.3.3` | `0.1.2-alpha.1` |
 | `0.1.4`, `0.2.x` | `0.1.1-rc.2` |
 
-Existing 0.3.3-0.3.13 apps do not need re-pairing. Earlier apps use a different status-bar strategy, so updating both is recommended. App 0.1.3 or earlier requires reinstalling and pairing again.
+Existing 0.3.3-0.3.14 apps do not need re-pairing. Earlier apps use a different status-bar strategy, so updating both is recommended. App 0.1.3 or earlier requires reinstalling and pairing again.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 > DSH Mobile 是 DeepSeek Harness 社区插件，原生 App 仅支持 Android。
 >
-> **0.3.13 更新**：第三方插件 WebSocket 连接拦截即通用一键放行——按目录分组、红点双入口、手动配置收进高级项（#47）+ 面板修整（FRP 步骤编号、部署说明排版、批准按钮）+ 适配 DeepSeek Harness 0.1.3-alpha.2（布局右栏插槽更名）。[详细记录](CHANGELOG.md)。
+> **0.3.14 更新**：0.3.13 的一个布局回归已修复——移动页右栏（详情面板）现在同时适配已发布的 0.1.3-alpha.2 与更新开发线，两种宿主都能显示；0.3.13 带来的功能不变（第三方 WebSocket 一键放行 #47、面板修整、读屏播报）。[详细记录](CHANGELOG.md)。
 >
-> **升级提醒**：先看电脑端 DeepSeek Harness 版本再升插件——**0.1.3-alpha.2 及以上**用插件 **0.3.13**；电脑端为更早版本（0.1.2 线或 0.1.3-alpha.1）时请保持插件 **0.3.12**。现有 0.3.3-0.3.12 App 可继续使用，无需重新配对。[兼容说明](#兼容性)。
+> **升级提醒**：推荐升级到插件 **0.3.14**（0.1.3 各版本桌面均适用，含 alpha.1）。安装新插件后需重启 DSH。现有 0.3.3-0.3.13 App 可继续使用，无需重新配对。[兼容说明](#兼容性)。
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.13/dsh-mobile-android-v0.3.13.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.13/dsh-mobile-android-v0.3.13.apk"><strong>下载 Android App 0.3.13</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.13">版本说明与校验文件</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.14/dsh-mobile-android-v0.3.14.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.14/dsh-mobile-android-v0.3.14.apk"><strong>下载 Android App 0.3.14</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.14">版本说明与校验文件</a></sub>
 </p>
 
 DSH Mobile 是一个 DeepSeek Harness 插件，让手机浏览器或 Android App 通过局域网，或可选的 Tailscale Funnel、cpolar、自建 FRP 远程通道连接电脑，继续使用同一份会话、工作区、消息和工具。局域网与远程访问分别启停、分别管理设备，且都不修改 DeepSeek Harness 源码。
@@ -210,14 +210,14 @@ flowchart LR
 
 | DSH Mobile 插件 | 验证支持的 DeepSeek Harness 版本 |
 | --- | --- |
-| `0.3.13` | `0.1.3-alpha.2` |
+| `0.3.14` | `0.1.3-alpha.2` |
 | `0.3.9`-`0.3.12` | `0.1.3-alpha.1` |
 | `0.3.6`-`0.3.8` | `0.1.2-rc.1` |
 | `0.3.4`、`0.3.5` | `0.1.2-alpha.2` |
 | `0.3.0`-`0.3.3` | `0.1.2-alpha.1` |
 | `0.1.4`、`0.2.x` | `0.1.1-rc.2` |
 
-现有 0.3.3-0.3.13 App 无需重新配对；更早的 App 使用不同的状态栏策略，建议同步升级；App 0.1.3 及更早版本需卸载重装并重新配对。
+现有 0.3.3-0.3.14 App 无需重新配对；更早的 App 使用不同的状态栏策略，建议同步升级；App 0.1.3 及更早版本需卸载重装并重新配对。
 
 ## 卸载
 

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "io.github.sayach.dshmobile"
         minSdk = 29
         targetSdk = 36
-        versionCode = 58
-        versionName = "0.3.13"
+        versionCode = 59
+        versionName = "0.3.14"
     }
 
     signingConfigs {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-mobile",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "private": false,
   "description": "DeepSeek Harness 移动端适配与安全访问插件，支持局域网、远程连接、Android App 和手机浏览器。",
   "type": "module",

--- a/src/mobile-layout.ts
+++ b/src/mobile-layout.ts
@@ -315,13 +315,21 @@ function MobileAppFrame(props: MobileRootProps & { readonly controller: MobileLa
       className: 'dshm-details',
       'data-open': state.detailsOpen,
       ...(state.detailsOpen ? {} : { inert: '' }),
-    }, hasSession ? props.renderSlot('rightbar', {
-      width: Math.min(window.innerWidth * 0.94, 460),
-      viewportWidth: window.innerWidth,
-      // Right track needs ~300px next to a ~400px center; below that the
-      // column cannot show and narrow phones see the drawer overlay instead.
-      canShow: window.innerWidth >= 720,
-    }) : undefined),
+    }, hasSession ? [
+      // Dual right-seat rendering across harness generations: 0.1.3-alpha.2
+      // and earlier expose the `details` seat (empty owner share); the master
+      // layout line renamed it `rightbar` with resolved column geometry.
+      // Each host mounts content for exactly one of the two names, so the
+      // other slot renders empty without error.
+      props.renderSlot('details', {}),
+      props.renderSlot('rightbar', {
+        width: Math.min(window.innerWidth * 0.94, 460),
+        viewportWidth: window.innerWidth,
+        // Right track needs ~300px next to a ~400px center; below that the
+        // column cannot show and narrow phones see the drawer overlay instead.
+        canShow: window.innerWidth >= 720,
+      }),
+    ] : undefined),
     createElement('div', { className: 'dshm-overlay', 'data-shell-overlay': true }, props.renderSlot('shell.overlay', {})),
   )
 }
@@ -346,6 +354,7 @@ export function apply(ctx: MobileClientContext): void {
         sidebar: { kind: 'single', scope: 'root' },
         conversation: { kind: 'single', scope: 'session-maybe' },
         rightbar: { kind: 'single', scope: 'session' },
+        details: { kind: 'single', scope: 'session' },
         'shell.overlay': { kind: 'list', scope: 'root' },
       },
     }, props => createElement(MobileAppFrame, { ...props, controller }))


### PR DESCRIPTION
Fixes the 0.3.13 layout regression: the adaptation tracked the harness master rename (`details` → `rightbar`), but the published 0.1.3-alpha.2 host still exposes `details` — real hosts rendered the mobile right panel empty. 0.3.14 registers and renders both seat names (`details` legacy empty owner, `rightbar` with column geometry); each host mounts content for exactly one and the other renders empty.

Bumps to 0.3.14 (Android code 59); bilingual CHANGELOG/README/release notes updated (0.3.14 works on every 0.1.3 desktop line).