### PR TITLE
fix(gateway): proxy an upstream whose browser auth is disabled

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -76,11 +76,28 @@ interface BrowserAuthenticatedConnection {
   authenticatedUrl?: (baseUrl: string) => string
 }
 
-function upstreamAuthenticatedUrl(ctx: Context, upstreamOrigin: URL): string | undefined {
+/**
+ * Resolve the DSH launch-token URL the gateway exchanges for its upstream cookie.
+ *
+ * A layer that disables DSH browser authentication — dsh-lan-access with
+ * `noAuth: true` replaces `authenticatedUrl` with one returning the bare origin
+ * — produces a URL with no query string, so it cannot carry a launch token. That
+ * is a legitimate "this upstream needs no browser auth" signal: report no URL and
+ * the gateway proxies without a cookie instead of failing every route with
+ * `upstream_unavailable`. A token-bearing URL keeps the existing exchange, and a
+ * connection service that is absent or returns a malformed URL keeps failing
+ * closed. Only parsing is guarded: a connection service that throws still fails
+ * plugin activation loudly rather than silently proxying without authentication.
+ */
+export function upstreamAuthenticatedUrl(ctx: Context, upstreamOrigin: URL): string | undefined {
   const connection = (ctx as Context & { readonly connection?: BrowserAuthenticatedConnection }).connection
-  return typeof connection?.authenticatedUrl === 'function'
-    ? connection.authenticatedUrl(upstreamOrigin.origin)
-    : undefined
+  if (typeof connection?.authenticatedUrl !== 'function') return undefined
+  const authenticatedUrl = connection.authenticatedUrl(upstreamOrigin.origin)
+  try {
+    return new URL(authenticatedUrl).search === '' ? undefined : authenticatedUrl
+  } catch {
+    return undefined
+  }
 }
 
 function installedDshVersion(): string {

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { Config, parseGatewayConfig } from '../src/config.js'
 import { parseCidr, RequestTrustPolicy } from '../src/network.js'
-import { apply, inject, remoteGatewayConfig, settleCleanupSteps } from '../src/plugin.js'
+import { apply, inject, remoteGatewayConfig, settleCleanupSteps, upstreamAuthenticatedUrl } from '../src/plugin.js'
 import { DSH_MOBILE_VERSION, MINIMUM_ANDROID_APP_VERSION } from '../src/version.js'
 
 const contexts: Context[] = []
@@ -97,6 +97,48 @@ async function mount(initiallyEnabled = false, webServerPort = 3080): Promise<{ 
   if (command === undefined) throw new Error('plugin did not register its /mobile command')
   return { context, route, command, upstreamBase }
 }
+
+describe('upstream browser authentication', () => {
+  const upstreamOrigin = new URL('http://127.0.0.1:3080')
+  const withConnection = (connection: unknown): Context => ({ connection } as unknown as Context)
+
+  it('keeps the launch-token URL a stock DSH connection returns', () => {
+    const authenticatedUrl = upstreamAuthenticatedUrl(withConnection({
+      authenticatedUrl: (baseUrl: string) => `${baseUrl}/?token=launch-token`,
+    }), upstreamOrigin)
+    expect(authenticatedUrl).toBe('http://127.0.0.1:3080/?token=launch-token')
+  })
+
+  it('reports no upstream URL when browser authentication is disabled, so the gateway proxies without a cookie', () => {
+    // dsh-lan-access `noAuth: true` replaces `authenticatedUrl` with one that
+    // returns the bare origin. Handing that URL to the gateway made its cookie
+    // exchange reject every proxied route with `upstream_unavailable`.
+    const authenticatedUrl = upstreamAuthenticatedUrl(withConnection({
+      authenticatedUrl: (baseUrl: string) => baseUrl,
+    }), upstreamOrigin)
+    expect(authenticatedUrl).toBeUndefined()
+  })
+
+  it('reports no upstream URL when the connection service exposes no browser authentication', () => {
+    expect(upstreamAuthenticatedUrl(withConnection(undefined), upstreamOrigin)).toBeUndefined()
+    expect(upstreamAuthenticatedUrl(withConnection({}), upstreamOrigin)).toBeUndefined()
+    expect(upstreamAuthenticatedUrl(withConnection({ authenticatedUrl: 'not-a-function' }), upstreamOrigin)).toBeUndefined()
+  })
+
+  it('reports no upstream URL when the connection service returns a malformed URL', () => {
+    expect(upstreamAuthenticatedUrl(withConnection({
+      authenticatedUrl: () => 'not a url',
+    }), upstreamOrigin)).toBeUndefined()
+  })
+
+  it('does not swallow a failing connection service', () => {
+    // Only parsing the returned URL is guarded. A broken connection service must
+    // keep failing plugin activation instead of silently proxying unauthenticated.
+    expect(() => upstreamAuthenticatedUrl(withConnection({
+      authenticatedUrl: () => { throw new Error('connection unavailable') },
+    }), upstreamOrigin)).toThrow('connection unavailable')
+  })
+})
 
 describe('remote Funnel gateway configuration', () => {
   it('keeps public HTTPS on 443 when the private listener uses an ephemeral port', () => {


### PR DESCRIPTION
## Symptom

With `dsh-lan-access` installed and `noAuth: true`, every LAN and remote pairing shows **"电脑端 DSH 暂不可用"** in the Android app, and the gateway answers every proxied route with `502 {"error":"upstream_unavailable"}` — even though the loopback DSH origin is perfectly healthy (`GET http://127.0.0.1:3080/` → 200).

## Root cause

`dsh-lan-access`'s `noAuth` option replaces `Connection.authenticatedUrl()` with one that returns the base URL unchanged, so the URL carries no DSH launch token:

```js
prototype["authenticatedUrl"] = function (baseUrl) { return baseUrl }
```

`upstreamAuthenticatedUrl()` only checked that the method *exists*, so it handed the bare `http://127.0.0.1:3080` to the gateway. `MobileAccessGateway.exchangeUpstreamCookie()` requires that URL to carry a query string (`target.search === ''` → `HttpError(502, 'upstream_unavailable')`), so it threw **before contacting the upstream**. The index, the mobile boot batch, static assets, and the WebSocket upgrade all share that path, so the app received 502 → `LoadFailure.SERVICE_UNAVAILABLE` → "电脑端 DSH 暂不可用", on LAN and remote alike (both reach the same gateway).

Reproduced on a live instance: pairing a device and requesting `/` through the gateway returned `502 {"error":"upstream_unavailable"}`, while the identical upstream request outside the gateway returned 200 with the HTML that `rewriteMobileIndex()` accepts.

## Fix

A URL with **no query string cannot carry a launch token**, so treat it as "this upstream needs no browser auth" and report no URL. `upstreamCookieHeader()` then returns `undefined` and the gateway proxies without a cookie — the same path it already takes when a host exposes no `connection.authenticatedUrl` at all.

- A token-bearing URL (stock DSH) is returned unchanged and still takes the existing launch-token exchange — no behavior change for the normal case.
- The only behavior that changes is a URL that is **guaranteed** to fail today: the gateway can never exchange a query-less URL for a cookie.
- A missing or malformed `authenticatedUrl` fails closed. Only *parsing* the returned URL is guarded, so a connection service that throws still fails plugin activation loudly instead of silently proxying without authentication.

`src/gateway.ts` is untouched — this only changes how the plugin derives the upstream auth URL, so no gateway rejection path is relaxed.

## Security review

- **The phone-facing gate is unchanged.** Every route that consults the upstream credential — `proxyMobileIndex`, `proxyHttp`, the mobile boot batch, and the WebSocket upgrade — runs after `this.authorize(request)` in `handleExternalRequest`, so a valid paired-device session (and CSRF for mutations) is still required first. Nothing becomes reachable to an unpaired client.
- **The change can only *remove* an upstream credential, never add or widen one.** `undefined` makes `upstreamCookieHeader()` return nothing, and `sanitizeRequestHeaders()` builds the upstream request from an explicit allow-list that excludes `cookie`/`authorization` — so the gateway presents no credentials at all, and the phone's own gateway cookies are never forwarded upstream.
- **Every route still fails closed.** The index and boot batch require upstream 200 (`!== 200` → 502), the WebSocket requires a 101 handshake (otherwise 502), and `proxyHttp` forwards the upstream status verbatim — an upstream that does require auth answers 401 to an already-authenticated device, which grants nothing.
- **The new branch only fires on input that cannot work today.** A query-less URL can never satisfy the gateway's existing `target.search === ''` guard, so no currently-working configuration changes behavior. Stock DSH always returns `/?token=...`, which is returned unchanged.
- **No public API change.** `src/index.ts` still exports only `apply, inject, name`, and the built bundle's export list is unchanged; the new module-level export follows `settleCleanupSteps` / `remoteGatewayConfig`, which exist for tests only.

## Tests

`tests/plugin.test.ts` gains five cases covering the changed derivation:

| Case | Expected |
| --- | --- |
| launch-token URL (stock DSH) | returned unchanged |
| query-less URL (dsh-lan-access `noAuth`) | `undefined` |
| missing / non-function `authenticatedUrl` | `undefined` |
| malformed URL | `undefined` |
| throwing connection service | still throws (not swallowed) |

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `npx vitest run tests/plugin.test.ts -t "upstream browser authentication"` — 5 passed
- Full suite, base `df8ffe8` vs this branch: identical 24 failures in 2 files (this sandbox refuses loopback connects to the tests' own ephemeral listeners); passing tests go 353 → 358 with the five new ones.

## Notes

This is a compatibility fix for my own plugin, [`dsh-lan-access`](https://github.com/longisland-icetea/dsh-lan-access), whose `noAuth` mode intentionally removes DSH's browser-auth gate on the LAN bind. After this change the two plugins can be used together; anyone hitting the 502 today can also work around it by setting `lan-access.noAuth: false`.
