### PR TITLE
fix(layout): expose stock pane anchors so remote plugins can mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
 
+## Unreleased
+
+- Keep the stock `data-pane="sidebar"` / `data-pane="conversation"` anchors (and a collapsed-rail `data-sidebar-collapsed` flag) on the dedicated remote layout so third-party center-column plugins such as `@linxin666/dsh-client-ui-task-board` can inject their sidebar entry and panel.
+
 ## 0.3.15 - 2026-09-11
 
 - Support the DeepSeek Harness 0.1.5 keyed `main` panel, root `panelInfo` hook, navigation lifecycle, and root right sidebar while retaining the earlier `conversation` and `details` paths.

--- a/src/mobile-layout.ts
+++ b/src/mobile-layout.ts
@@ -272,7 +272,7 @@ class ThemePresenter {
 export const MOBILE_LAYOUT_STYLES = `
 html,body,#root{width:100%;height:100%;overflow:hidden}
 .dshm-shell{position:relative;display:grid;width:100%;height:100dvh;min-width:0;overflow:hidden;background:var(--dsw-alias-bg-base,#fff)}
-.dshm-main{grid-area:1/1;min-width:0;min-height:0;overflow:hidden}
+.dshm-main{grid-area:1/1;position:relative;min-width:0;min-height:0;overflow:hidden}
 .dshm-main>*,.dshm-main>*>*{min-width:0}
 .dshm-drawer{position:fixed;z-index:70;inset:0 auto 0 0;box-sizing:border-box;width:56px;max-width:100%;padding-top:env(safe-area-inset-top);overflow:hidden;background:var(--dsw-alias-bg-layer-1,#f8fafc);box-shadow:none;will-change:width;transition:width 240ms cubic-bezier(.22,1,.36,1),box-shadow 240ms ease}
 .dshm-drawer[data-open=true]{width:min(88vw,340px);box-shadow:18px 0 46px rgb(15 23 42 / 18%)}
@@ -431,7 +431,16 @@ function MobileAppFrame(props: MobileRootProps & {
   }
 
   return createElement('div', { className: 'dshm-shell', lang: language },
-    createElement('main', { className: 'dshm-main', 'data-dsh-mobile-session': activeSessionId },
+    createElement('main', {
+      className: 'dshm-main',
+      'data-dsh-mobile-session': activeSessionId,
+      // Stock AppFrame names these columns `sidebar` / `conversation`. Third-party
+      // plugins such as `@linxin666/dsh-client-ui-task-board` scrape those pane
+      // attributes (or `*sidebarCol` / `*centerCol` class tokens) to inject a
+      // sidebar row and take over the center column. The dedicated remote layout
+      // must keep the same public anchors or those plugins mount nowhere.
+      'data-pane': 'conversation',
+    },
       props.renderSlot('main', {}, {
         entryKey: state.panelInfo.activePanelId ?? 'conversation',
         fallback: props.renderSlot('conversation', {}),
@@ -453,7 +462,12 @@ function MobileAppFrame(props: MobileRootProps & {
     createElement('aside', {
       'aria-label': messages.workspaceNavigation,
       className: 'dshm-drawer',
+      'data-pane': 'sidebar',
       'data-open': state.sidebarOpen,
+      // Task-board (and ssh) collapse their injected row when an ancestor carries
+      // this attribute; the stock frame sets it on the rail. Mirror it here so
+      // the 56px dedicated rail still shows an icon-only entry.
+      ...(state.sidebarOpen ? {} : { 'data-sidebar-collapsed': '' }),
       onClickCapture: closeDrawerAfterSessionAction,
     }, props.renderSlot('sidebar', {
       collapsed: !state.sidebarOpen,

--- a/tests/mobile-layout.test.ts
+++ b/tests/mobile-layout.test.ts
@@ -441,6 +441,14 @@ describe('dedicated mobile layout boot', () => {
     expect(source).toContain('return () => { document.title = productTitle }')
   })
 
+  it('exposes stock pane anchors so third-party center-column plugins can mount', () => {
+    const source = readFileSync(new URL('../src/mobile-layout.ts', import.meta.url), 'utf8')
+    expect(source).toContain("'data-pane': 'conversation'")
+    expect(source).toContain("'data-pane': 'sidebar'")
+    expect(source).toContain("'data-sidebar-collapsed': ''")
+    expect(MOBILE_LAYOUT_STYLES).toContain('.dshm-main{grid-area:1/1;position:relative;')
+  })
+
   it('opens the command menu without restoring focus to the mobile editor', () => {
     const source = readFileSync(new URL('../src/mobile-layout.ts', import.meta.url), 'utf8')
     expect(source).toContain("event.target.closest('button[aria-haspopup=\"listbox\"]')")


### PR DESCRIPTION
## Problem
On the dedicated LAN/remote frontend, third-party center-column plugins such as `@linxin666/dsh-client-ui-task-board` never appear. They do not use official slots; they scrape the stock AppFrame anchors `[data-pane="sidebar"]` / `[data-pane="conversation"]` (or `*sidebarCol` / `*centerCol`) to inject a sidebar row and take over the center column.

The dedicated layout only exposed `.dshm-drawer` / `.dshm-main`, so those plugins mounted nowhere. Loopback desktop (`127.0.0.1:3080`) still uses the stock frame, which is why the task board works locally and disappears remotely.

This is independent of #66 (rightbar docking / Better Sidebar).

## Changes
- Mark the dedicated center column with `data-pane="conversation"` and give `.dshm-main` `position: relative` so an absolute board overlay can fill it.
- Mark the dedicated drawer with `data-pane="sidebar"`.
- Set `data-sidebar-collapsed` on the 56px rail so injected rows keep their icon-only collapsed style.

## Automated validation
- `npx vitest run tests/mobile-layout.test.ts`: 38 passed.
- Layout suite includes a source/CSS contract test for the pane anchors.

## Scope
Only `src/mobile-layout.ts`, `tests/mobile-layout.test.ts`, and an Unreleased changelog note. No DSH core or task-board package changes.

## Related
- Does not replace or extend #66.