### PR TITLE
fix: harden mobile layout and custom DSH ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ Notable changes to DSH Mobile are recorded here. GitHub Releases remain the sour
 
 ## Unreleased
 
-- Keep the stock `data-pane="sidebar"` / `data-pane="conversation"` anchors (and a collapsed-rail `data-sidebar-collapsed` flag) on the dedicated remote layout so third-party center-column plugins such as `@linxin666/dsh-client-ui-task-board` can inject their sidebar entry and panel.
+- Provide legacy dsh-web community pane markers and a collapsed-rail marker on the dedicated layout so DOM-mounting plugins such as `@linxin666/dsh-client-ui-task-board` can inject their sidebar entry and panel (thanks @idoall for PR #67).
+- Preserve native rightbar track/fullscreen requests while shrinking or overlaying the panel whenever docking would leave less than 400 px for the conversation. The dedicated layout no longer consumes the retired Better Sidebar width variable (thanks @idoall for PR #66).
+- Follow the active DSH WebServer port for LAN and remote proxy authentication, including managed and legacy setup files that saved an older 3080 upstream. The independently configurable Mobile HTTPS listener remains unchanged (thanks @CharlesLueng for #68).
+- Limit the full-width question and plan-review adaptations to screens at most 600 px wide so desktop remote browsers retain DSH's native card width (thanks @idoall for #64).
 
 ## 0.3.15 - 2026-09-11
 

--- a/README.en.md
+++ b/README.en.md
@@ -99,6 +99,8 @@ Use this when the phone and computer share Wi-Fi, Ethernet, or a phone hotspot. 
 3. In the Android app, open **Local network**, scan for computers, select the device, then scan the QR code or paste the pairing key.
 4. Pairing creates persistent device trust. Later app launches discover and connect automatically; Wi-Fi, hotspot, and DHCP address changes normally do not require pairing again.
 
+Port note: `dsh web --port` changes the DSH Web upstream port (3080 by default), which the plugin follows automatically. `dsh-mobile setup --port` changes the Mobile HTTPS listener (3443 by default), and the pairing QR code includes the selected port.
+
 The app is optional: select **Copy pairing link** and open it in a mobile browser. The browser must manually trust the plugin certificate on the first visit.
 
 ### Remote access
@@ -182,7 +184,7 @@ flowchart LR
   Gateway -->|"loopback proxy"| DSH["Stock DSH Web and Host"]
 ```
 
-Three layers: the Host face for discovery, pairing, HTTPS, loopback proxying, and extension registration; the Client face for the dedicated mobile layout and extension SDK; and the Android app for a narrow native bridge. The bridge uses `androidx.webkit` WebMessage, verifies the exact top-level origin and main frame on every bounded message, and never uses `addJavascriptInterface`. Neither the DeepSeek Harness source nor its desktop page on port 3080 is modified.
+Three layers: the Host face for discovery, pairing, HTTPS, loopback proxying, and extension registration; the Client face for the dedicated mobile layout and extension SDK; and the Android app for a narrow native bridge. The bridge uses `androidx.webkit` WebMessage, verifies the exact top-level origin and main frame on every bounded message, and never uses `addJavascriptInterface`. Neither the DeepSeek Harness source nor its active Web page (port 3080 by default, configurable through `dsh web --port`) is modified.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ dsh plugin --profile web add dshmarket
 3. 在 Android App 中进入 **局域网访问**，扫描发现电脑并点击设备，再扫描二维码或粘贴配对密钥。
 4. 配对完成后会建立持久设备信任。以后打开 App 会自动发现并连接，切换 Wi-Fi、热点或 DHCP 地址通常不需要重新配对。
 
+端口说明：`dsh web --port` 修改 DSH Web 上游端口（默认 3080），插件会自动跟随；`dsh-mobile setup --port` 修改 Mobile HTTPS 监听端口（默认 3443），配对二维码会包含实际端口。
+
 不安装 App 也可以访问：点击 **复制配对链接**，在手机浏览器中打开；首次访问需要按浏览器提示手动信任插件证书。
 
 ### 远程访问
@@ -191,7 +193,7 @@ flowchart LR
   DSH -->|"同一工作区、会话和事件流"| Phone
 ```
 
-插件包含三层：Host face 负责发现、配对、HTTPS、回环代理和扩展注册表；Client face 提供独立的移动布局与扩展 SDK；Android App 提供受限的原生 Bridge。Bridge 使用 `androidx.webkit` WebMessage，每条消息都校验精确顶层 Origin 和主 Frame，并限制消息大小；不使用 `addJavascriptInterface`。DeepSeek Harness 的源码和 3080 桌面页面都不会被修改，安装和卸载完全通过插件机制完成。
+插件包含三层：Host face 负责发现、配对、HTTPS、回环代理和扩展注册表；Client face 提供独立的移动布局与扩展 SDK；Android App 提供受限的原生 Bridge。Bridge 使用 `androidx.webkit` WebMessage，每条消息都校验精确顶层 Origin 和主 Frame，并限制消息大小；不使用 `addJavascriptInterface`。DeepSeek Harness 的源码和当前 Web 页面（默认端口 3080，可通过 `dsh web --port` 修改）都不会被改动，安装和卸载完全通过插件机制完成。
 
 ## 安全
 

--- a/src/managed-setup.ts
+++ b/src/managed-setup.ts
@@ -22,6 +22,7 @@ export interface ManagedSetup {
   readonly version: 2
   readonly networkInterface: string
   readonly listenPort: number
+  /** Legacy setup snapshot retained for file compatibility; the active WebServer port wins at runtime. */
   readonly upstreamOrigin: string
   readonly tls: {
     readonly mode: 'managed'
@@ -308,7 +309,6 @@ export async function materializeManagedSetup(
   return {
     publicOrigin: `https://${network.address}:${String(setup.listenPort)}`,
     listenHost: network.address,
-    upstreamOrigin: setup.upstreamOrigin,
     allowedCidrs: [network.cidr],
     instanceId: ca.fingerprint256.replaceAll(':', '').toLowerCase(),
     pairingCaFile: setup.tls.caCertFile,

--- a/src/mobile-layout.ts
+++ b/src/mobile-layout.ts
@@ -87,18 +87,53 @@ export function isSidebarRightControl(value: unknown): value is SidebarRightCont
  * keep the overlay behavior byte-for-byte.
  */
 export const WIDE_LAYOUT_MIN_WIDTH_PX = 900
+const RIGHTBAR_MIN_WIDTH_PX = 300
+const RIGHTBAR_MAX_WIDTH_PX = 460
+const RIGHTBAR_CENTER_MIN_WIDTH_PX = 400
+const RIGHTBAR_DEFAULT_RATIO = 0.45
+const SIDEBAR_EXPANDED_WIDTH_PX = 340
+const SIDEBAR_COLLAPSED_WIDTH_PX = 56
 
 export function isWideViewportLayout(viewportWidth: number): boolean {
   return viewportWidth >= WIDE_LAYOUT_MIN_WIDTH_PX
 }
 
-/** Whether the narrow layout needs the modal scrim for either side panel. */
+/** Resolved right-panel presentation for the dedicated responsive layout. */
+export interface MobileRightbarLayout {
+  readonly docked: boolean
+  readonly width: number
+}
+
+/** Preserve a readable conversation width before turning a requested right track into a docked column. */
+export function resolveMobileRightbarLayout(
+  viewportWidth: number,
+  sidebarOpen: boolean,
+  track: boolean,
+  fullscreen: boolean,
+): MobileRightbarLayout {
+  const overlayWidth = Math.min(viewportWidth * 0.94, RIGHTBAR_MAX_WIDTH_PX)
+  if (!track || fullscreen || (!isWideViewportLayout(viewportWidth) && sidebarOpen)) {
+    return Object.freeze({ docked: false, width: overlayWidth })
+  }
+  const sidebarWidth = isWideViewportLayout(viewportWidth) && sidebarOpen
+    ? SIDEBAR_EXPANDED_WIDTH_PX
+    : SIDEBAR_COLLAPSED_WIDTH_PX
+  const available = Math.floor(viewportWidth - sidebarWidth - RIGHTBAR_CENTER_MIN_WIDTH_PX)
+  if (available < RIGHTBAR_MIN_WIDTH_PX) return Object.freeze({ docked: false, width: overlayWidth })
+  const preferred = Math.min(
+    RIGHTBAR_MAX_WIDTH_PX,
+    Math.max(RIGHTBAR_MIN_WIDTH_PX, Math.round(viewportWidth * RIGHTBAR_DEFAULT_RATIO)),
+  )
+  return Object.freeze({ docked: true, width: Math.min(preferred, available) })
+}
+
+/** Whether an overlay drawer needs the modal scrim without dimming a docked desktop panel. */
 export function isMobileScrimOpen(
   sidebarOpen: boolean,
-  detailsOpen: boolean,
+  detailsModalOpen: boolean,
   wideViewport: boolean,
 ): boolean {
-  return !wideViewport && (sidebarOpen || detailsOpen)
+  return (!wideViewport && sidebarOpen) || detailsModalOpen
 }
 
 /**
@@ -274,13 +309,8 @@ class ThemePresenter {
 export const MOBILE_LAYOUT_STYLES = `
 html,body,#root{width:100%;height:100%;overflow:hidden}
 .dshm-shell{position:relative;display:grid;width:100%;height:100dvh;min-width:0;overflow:hidden;background:var(--dsw-alias-bg-base,#fff)}
-.dshm-main{grid-area:1/1;position:relative;min-width:0;min-height:0;overflow:hidden}
-/* Better Sidebar publishes its live fixed-panel width on the root. Reserve
-   space only in the conversation cell: the composer and DSH header controls
-   reflow left, while the plugin's own top-right control cluster stays on its
-   official viewport-relative geometry. */
-.dshm-main{margin-right:var(--dsh-sidebar-width,0px);transition:margin-right var(--ds-transition-duration-slow,190ms) var(--ds-ease-in-out,ease)}
-.dshm-shell[data-rightbar-docked=true] .dshm-main{margin-right:calc(var(--dshm-rightbar-width) + var(--dsh-sidebar-width,0px))}
+.dshm-main{grid-area:1/1;position:relative;min-width:0;min-height:0;margin-right:0;overflow:hidden;transition:margin-right var(--ds-transition-duration-slow,190ms) var(--ds-ease-in-out,ease)}
+.dshm-shell[data-rightbar-docked=true] .dshm-main{margin-right:var(--dshm-rightbar-width)}
 .dshm-shell[data-rightbar-docked=true] .dshm-details{position:absolute;width:var(--dshm-rightbar-width);box-shadow:none;padding-top:0}
 /* Draw above the native absolute panel without consuming its width or
    intercepting controls; only docked mode needs this column separator. */
@@ -309,11 +339,11 @@ html,body,#root{width:100%;height:100%;overflow:hidden}
 .dshm-shell [data-disclosure-row]>*{min-width:0;overflow-wrap:anywhere}
 .dshm-shell [data-context-fields]>*{min-width:0}
 .dshm-shell [class*="_body"]{max-width:100%;overflow-wrap:anywhere}
+@media(max-width:420px){.dshm-shell [data-context-fields]>*{display:grid;grid-template-columns:1fr!important;gap:4px}.dshm-shell [class*="_ioSection"]{grid-template-columns:1fr!important}}
+@media(max-width:600px){
 .dshm-shell [data-question-key],.dshm-shell [data-plan-review-key]{box-sizing:border-box;width:100%;height:auto!important;min-width:0;flex:none!important;align-self:flex-end;padding:6px max(10px,env(safe-area-inset-left)) max(10px,env(safe-area-inset-bottom)) max(10px,env(safe-area-inset-right))!important}
 .dshm-shell [data-question-key]>section,.dshm-shell [data-plan-review-key]>section{width:100%;height:auto!important;min-height:0!important;max-width:none!important;max-height:min(68dvh,520px)!important;border-radius:16px!important}
 .dshm-shell [data-question-scroll],.dshm-shell [data-plan-review-scroll]{flex:0 1 auto!important;min-height:0!important;max-height:min(42dvh,360px)!important;overscroll-behavior:contain;scroll-padding-bottom:12px}
-@media(max-width:420px){.dshm-shell [data-context-fields]>*{display:grid;grid-template-columns:1fr!important;gap:4px}.dshm-shell [class*="_ioSection"]{grid-template-columns:1fr!important}}
-@media(max-width:600px){
 .dshm-shell [data-question-key]>section>header{display:flex!important;visibility:visible!important;flex:none!important;gap:8px!important;padding:12px 8px 4px 14px!important}
 .dshm-shell [data-question-key]>section>header h2{min-width:0;overflow-wrap:anywhere;font-size:16px!important;line-height:22px!important}
 .dshm-shell [data-question-key]>section>header button{min-width:40px;min-height:40px}
@@ -333,9 +363,6 @@ html,body,#root{width:100%;height:100%;overflow:hidden}
 .dshm-drawer[data-open=true]{width:340px;box-shadow:none}
 .dshm-drawer[data-open=false]{width:56px}
 }
-/* Better Sidebar already exposes this drag-state contract. Do not animate the
-   mobile conversation edge while its panel width is being resized. */
-body[data-dsh-sidebar-dragging] .dshm-main{transition:none}
 @media(prefers-reduced-motion:reduce){.dshm-drawer,.dshm-details,.dshm-scrim,.dshm-drawer>*,.dshm-main{transition:none!important}}
 `
 
@@ -345,15 +372,30 @@ function MobileAppFrame(props: MobileRootProps & {
 }): ReactNode {
   const state = useSyncExternalStore(props.controller.subscribe, props.controller.getSnapshot)
   const suppressKeyboardUntil = useRef(0)
-  const [wideViewport, setWideViewport] = useState(viewportIsWide)
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth)
   useEffect(() => {
-    const resize = (): void => { setViewportWidth(window.innerWidth) }
+    let frame: number | undefined
+    const resize = (): void => {
+      if (frame !== undefined) return
+      frame = window.requestAnimationFrame(() => {
+        frame = undefined
+        setViewportWidth(window.innerWidth)
+      })
+    }
     window.addEventListener('resize', resize)
-    return () => { window.removeEventListener('resize', resize) }
+    return () => {
+      window.removeEventListener('resize', resize)
+      if (frame !== undefined) window.cancelAnimationFrame(frame)
+    }
   }, [])
-  const rightbarWidth = Math.min(viewportWidth * 0.45, 460)
-  const rightbarDocked = viewportWidth >= 768 && state.detailsOpen && state.rightbarTrack && !state.rightbarFullscreen
+  const wideViewport = isWideViewportLayout(viewportWidth)
+  const rightbar = resolveMobileRightbarLayout(
+    viewportWidth,
+    state.sidebarOpen,
+    state.rightbarTrack,
+    state.rightbarFullscreen,
+  )
+  const rightbarDocked = state.detailsOpen && rightbar.docked
   const [documentLanguage, setDocumentLanguage] = useState(document.documentElement.lang)
   const browserLanguages = navigator.languages.length > 0 ? navigator.languages : [navigator.language]
   const language = resolveMobileLayoutLanguage(documentLanguage, browserLanguages)
@@ -364,15 +406,6 @@ function MobileAppFrame(props: MobileRootProps & {
     return current !== undefined && session.byId[current]?.blank === false ? current : undefined
   })
   const hasSession = activeSessionId !== undefined
-
-  useEffect(() => {
-    if (typeof window.matchMedia !== 'function') return
-    const query = window.matchMedia(`(min-width: ${WIDE_LAYOUT_MIN_WIDTH_PX}px)`)
-    const syncViewport = (): void => { setWideViewport(query.matches) }
-    syncViewport()
-    query.addEventListener('change', syncViewport)
-    return () => { query.removeEventListener('change', syncViewport) }
-  }, [])
 
   useEffect(() => {
     const observer = new MutationObserver(() => { setDocumentLanguage(document.documentElement.lang) })
@@ -458,16 +491,13 @@ function MobileAppFrame(props: MobileRootProps & {
   return createElement('div', {
     className: 'dshm-shell', lang: language,
     'data-rightbar-docked': rightbarDocked,
-    style: { '--dshm-rightbar-width': `${rightbarWidth}px` },
+    style: { '--dshm-rightbar-width': `${rightbar.width}px` },
   },
     createElement('main', {
       className: 'dshm-main',
       'data-dsh-mobile-session': activeSessionId,
-      // Stock AppFrame names these columns `sidebar` / `conversation`. Third-party
-      // plugins such as `@linxin666/dsh-client-ui-task-board` scrape those pane
-      // attributes (or `*sidebarCol` / `*centerCol` class tokens) to inject a
-      // sidebar row and take over the center column. The dedicated remote layout
-      // must keep the same public anchors or those plugins mount nowhere.
+      // Legacy dsh-web community plugins use semantic pane attributes as their
+      // compatibility path when the stock CSS-module column names are absent.
       'data-pane': 'conversation',
     },
       props.renderSlot('main', {}, {
@@ -497,9 +527,7 @@ function MobileAppFrame(props: MobileRootProps & {
       // Remove that entire navigation surface while the right modal owns focus.
       'data-right-modal': state.detailsOpen && !rightbarDocked,
       ...(state.detailsOpen && !rightbarDocked ? { inert: '', 'aria-hidden': true } : {}),
-      // Task-board (and ssh) collapse their injected row when an ancestor carries
-      // this attribute; the stock frame sets it on the rail. Mirror it here so
-      // the 56px dedicated rail still shows an icon-only entry.
+      // Community rows collapse their label when an ancestor carries this marker.
       ...(state.sidebarOpen ? {} : { 'data-sidebar-collapsed': '' }),
       onClickCapture: closeDrawerAfterSessionAction,
     }, props.renderSlot('sidebar', {
@@ -517,7 +545,7 @@ function MobileAppFrame(props: MobileRootProps & {
       // occupant must stay mounted even while no Session is selected.
       hasSession ? props.renderSlot('details', {}) : undefined,
       props.renderSlot('rightbar', {
-        width: viewportWidth >= 768 ? rightbarWidth : Math.min(viewportWidth * 0.94, 460),
+        width: rightbar.width,
         viewportWidth,
         // The official frame reports whether a persistent column still fits
         // (normal.rightbar > 0); this layout renders the right panel in the

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -204,6 +204,7 @@ async function loadSetup(config: PluginConfig): Promise<LoadedSetup> {
     throw new Error('mobile setup file has an unsupported format')
   }
   const { version: _version, ...setup } = record
+  delete setup.upstreamOrigin
   return {
     kind: 'fixed',
     config: { ...withoutSetupKeys(config), ...setup } as unknown as PluginConfig,
@@ -212,11 +213,12 @@ async function loadSetup(config: PluginConfig): Promise<LoadedSetup> {
 
 function loopbackTemplate(loaded: LoadedSetup, webServerPort: number): ResolvedGatewayConfig {
   const base = withoutSetupKeys(loaded.config)
+  const activeUpstreamOrigin = `http://127.0.0.1:${String(webServerPort)}`
   return parseGatewayConfig({
     ...base,
     ...(loaded.kind === 'managed'
-      ? { upstreamOrigin: loaded.setup.upstreamOrigin }
-      : { upstreamOrigin: loaded.config.upstreamOrigin ?? `http://127.0.0.1:${String(webServerPort)}` }),
+      ? { upstreamOrigin: activeUpstreamOrigin }
+      : { upstreamOrigin: loaded.config.upstreamOrigin ?? activeUpstreamOrigin }),
     listenHost: '127.0.0.1',
     listenPort: 0,
     publicAuthorities: ['127.0.0.1'],
@@ -359,7 +361,10 @@ export async function apply(ctx: Context, config: PluginConfig): Promise<void> {
   const blockedUpgradePaths = new BlockedUpgradePathLog()
   let lanGateway: MobileAccessGateway | undefined
   const startGateway = async (candidateConfig: PluginConfig): Promise<MobileAccessRuntime> => {
-    const resolved = parseGatewayConfig(candidateConfig)
+    const resolved = parseGatewayConfig({
+      ...candidateConfig,
+      upstreamOrigin: template.upstreamOrigin.origin,
+    })
     const candidate = new MobileAccessGateway(
       resolved,
       new JsonDeviceStore(resolved.stateFile, resolved.maxDevices),

--- a/tests/managed-setup.test.ts
+++ b/tests/managed-setup.test.ts
@@ -130,6 +130,17 @@ describe('managed DHCP setup', () => {
     expect(persistedCa.fingerprint256).toBe(ca.fingerprint256)
   })
 
+  it('keeps a custom Mobile HTTPS port independent from the active DSH Web port', async () => {
+    const setup = { ...await fixture(), listenPort: 4567 }
+    await ensureManagedCa(setup.tls)
+    const config = await materializeManagedSetup(setup, interfaceTable('192.168.50.23'))
+    expect(config).toMatchObject({
+      publicOrigin: 'https://192.168.50.23:4567',
+      listenHost: '192.168.50.23',
+    })
+    expect(config).not.toHaveProperty('upstreamOrigin')
+  })
+
   it('rejects unknown durable fields before using paths', () => {
     expect(() => parseManagedSetup({
       version: 2,

--- a/tests/mobile-layout.test.ts
+++ b/tests/mobile-layout.test.ts
@@ -13,6 +13,7 @@ import {
   isSidebarRightControl,
   isWideViewportLayout,
   resolveMobileLayoutLanguage,
+  resolveMobileRightbarLayout,
 } from '../src/mobile-layout.js'
 
 function index(entries: unknown[]): string {
@@ -348,14 +349,22 @@ describe('dedicated mobile layout boot', () => {
   })
 
   it('adapts stable DSH question surfaces for touch screens', () => {
-    expect(MOBILE_LAYOUT_STYLES).toContain('[data-question-key]')
-    expect(MOBILE_LAYOUT_STYLES).toContain('[data-question-scroll]')
-    expect(MOBILE_LAYOUT_STYLES).toContain('[data-plan-review-key]')
-    expect(MOBILE_LAYOUT_STYLES).toContain('[data-plan-review-scroll]')
-    expect(MOBILE_LAYOUT_STYLES).toContain('[data-plan-review-key]>section>div:last-child')
-    expect(MOBILE_LAYOUT_STYLES).toContain('max-height:min(42dvh,360px)')
-    expect(MOBILE_LAYOUT_STYLES).toContain('height:auto!important')
-    expect(MOBILE_LAYOUT_STYLES).toContain('min-height:44px')
+    const narrowStart = MOBILE_LAYOUT_STYLES.indexOf('@media(max-width:600px){')
+    const wideStart = MOBILE_LAYOUT_STYLES.indexOf('@media(min-width:900px){')
+    expect(narrowStart).toBeGreaterThan(0)
+    expect(wideStart).toBeGreaterThan(narrowStart)
+    const shared = MOBILE_LAYOUT_STYLES.slice(0, narrowStart)
+    const narrow = MOBILE_LAYOUT_STYLES.slice(narrowStart, wideStart)
+    expect(shared).not.toContain('[data-question-key]')
+    expect(shared).not.toContain('[data-plan-review-key]')
+    expect(narrow).toContain('[data-question-key]')
+    expect(narrow).toContain('[data-question-scroll]')
+    expect(narrow).toContain('[data-plan-review-key]')
+    expect(narrow).toContain('[data-plan-review-scroll]')
+    expect(narrow).toContain('[data-plan-review-key]>section>div:last-child')
+    expect(narrow).toContain('max-height:min(42dvh,360px)')
+    expect(narrow).toContain('height:auto!important')
+    expect(narrow).toContain('min-height:44px')
   })
 
   it('treats viewports at least 900px wide as a persistent desktop sidebar', () => {
@@ -371,12 +380,12 @@ describe('dedicated mobile layout boot', () => {
     [false, true, false, true],
     [true, true, false, true],
     [true, false, true, false],
-    [false, true, true, false],
-    [true, true, true, false],
+    [false, true, true, true],
+    [true, true, true, true],
   ])(
-    'shows the modal scrim for sidebar=%s details=%s wide=%s as %s',
-    (sidebarOpen, detailsOpen, wideViewport, expected) => {
-      expect(isMobileScrimOpen(sidebarOpen, detailsOpen, wideViewport)).toBe(expected)
+    'shows the modal scrim for sidebar=%s detailsModal=%s wide=%s as %s',
+    (sidebarOpen, detailsModalOpen, wideViewport, expected) => {
+      expect(isMobileScrimOpen(sidebarOpen, detailsModalOpen, wideViewport)).toBe(expected)
     },
   )
 
@@ -415,12 +424,30 @@ describe('dedicated mobile layout boot', () => {
     expect(isSidebarRightControl({ toggleExpanded: () => {} })).toBe(false)
   })
 
-  it('reserves only the conversation cell for Better Sidebar panels', () => {
-    // Preserve Better Sidebar's official viewport-relative toggle cluster:
-    // only the DSH-Mobile content cell consumes its width variable.
-    expect(MOBILE_LAYOUT_STYLES).toContain('.dshm-main{margin-right:var(--dsh-sidebar-width,0px)')
-    expect(MOBILE_LAYOUT_STYLES).toContain('body[data-dsh-sidebar-dragging] .dshm-main{transition:none}')
-    expect(MOBILE_LAYOUT_STYLES).not.toContain('.dshm-shell{margin-right:var(--dsh-sidebar-width,0px)')
+  it.each([
+    [755, false, true, false, false, 460],
+    [756, false, true, false, true, 300],
+    [899, false, true, false, true, 405],
+    [899, true, true, false, false, 460],
+    [900, true, true, false, false, 460],
+    [900, false, true, false, true, 405],
+    [1039, true, true, false, false, 460],
+    [1040, true, true, false, true, 300],
+    [1200, true, true, false, true, 460],
+    [1200, true, false, false, false, 460],
+    [1200, true, true, true, false, 460],
+  ] as const)(
+    'resolves rightbar viewport=%i sidebar=%s track=%s fullscreen=%s as docked=%s width=%i',
+    (viewport, sidebarOpen, track, fullscreen, docked, width) => {
+      expect(resolveMobileRightbarLayout(viewport, sidebarOpen, track, fullscreen)).toEqual({ docked, width })
+    },
+  )
+
+  it('reserves only the resolved native rightbar track', () => {
+    expect(MOBILE_LAYOUT_STYLES).toContain('margin-right:0;')
+    expect(MOBILE_LAYOUT_STYLES).toContain('.dshm-shell[data-rightbar-docked=true] .dshm-main{margin-right:var(--dshm-rightbar-width)}')
+    expect(MOBILE_LAYOUT_STYLES).not.toContain('--dsh-sidebar-width')
+    expect(MOBILE_LAYOUT_STYLES).not.toContain('data-dsh-sidebar-dragging')
   })
 
   it('draws a theme-aware docked separator without changing geometry or hit targets', () => {
@@ -460,7 +487,7 @@ describe('dedicated mobile layout boot', () => {
     expect(source).toContain('return () => { document.title = productTitle }')
   })
 
-  it('exposes stock pane anchors so third-party center-column plugins can mount', () => {
+  it('exposes legacy dsh-web pane anchors so community center-column plugins can mount', () => {
     const source = readFileSync(new URL('../src/mobile-layout.ts', import.meta.url), 'utf8')
     expect(source).toContain("'data-pane': 'conversation'")
     expect(source).toContain("'data-pane': 'sidebar'")

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -2,12 +2,13 @@ import { Context } from '@deepseek-ai/cordis'
 import type { WebRoute, WebServer } from '@deepseek-ai/dsh-host-webserver'
 import type { CommandDefinition } from '@deepseek-ai/dsh-commands'
 import { createServer, request as requestHttp } from 'node:http'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import type { AddressInfo } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { generate } from 'selfsigned'
 import { afterEach, describe, expect, it } from 'vitest'
-import { Config, parseGatewayConfig } from '../src/config.js'
+import { Config, parseGatewayConfig, type PluginConfig } from '../src/config.js'
 import { parseCidr, RequestTrustPolicy } from '../src/network.js'
 import { apply, inject, remoteGatewayConfig, settleCleanupSteps, upstreamAuthenticatedUrl } from '../src/plugin.js'
 import { DSH_MOBILE_VERSION, MINIMUM_ANDROID_APP_VERSION } from '../src/version.js'
@@ -57,7 +58,11 @@ async function invoke(route: WebRoute, method: 'GET' | 'POST', path: string, bod
   }
 }
 
-async function mount(initiallyEnabled = false, webServerPort = 3080): Promise<{ context: Context; route: WebRoute; command: CommandDefinition; upstreamBase: string | undefined }> {
+async function mount(
+  initiallyEnabled = false,
+  webServerPort = 3080,
+  config: Partial<PluginConfig> = {},
+): Promise<{ context: Context; route: WebRoute; command: CommandDefinition; upstreamBase: string | undefined }> {
   const directory = await mkdtemp(join(tmpdir(), 'dsh-mobile-plugin-'))
   temporaryDirectories.push(directory)
   let route: WebRoute | undefined
@@ -92,10 +97,39 @@ async function mount(initiallyEnabled = false, webServerPort = 3080): Promise<{ 
     customScriptFile: join(directory, 'mobile.js'),
     initiallyEnabled,
     tls: { mode: 'disabled' },
+    ...config,
   })
   if (route === undefined) throw new Error('plugin did not register its control route')
   if (command === undefined) throw new Error('plugin did not register its /mobile command')
   return { context, route, command, upstreamBase }
+}
+
+async function managedSetupFile(upstreamOrigin: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'dsh-mobile-managed-plugin-'))
+  temporaryDirectories.push(directory)
+  const generated = await generate([{ name: 'commonName', value: 'DSH Mobile test CA' }], {
+    keyType: 'ec',
+    curve: 'P-256',
+    algorithm: 'sha256',
+    extensions: [{ name: 'basicConstraints', cA: true, critical: true }],
+  })
+  const caCertFile = join(directory, 'ca.pem')
+  await writeFile(caCertFile, generated.cert)
+  const setupFile = join(directory, 'setup.json')
+  await writeFile(setupFile, JSON.stringify({
+    version: 2,
+    networkInterface: 'unused-while-disabled',
+    listenPort: 3443,
+    upstreamOrigin,
+    tls: {
+      mode: 'managed',
+      caCertFile,
+      caKeyFile: join(directory, 'ca-key.pem'),
+      certFile: join(directory, 'server.pem'),
+      keyFile: join(directory, 'server-key.pem'),
+    },
+  }))
+  return setupFile
 }
 
 describe('upstream browser authentication', () => {
@@ -258,6 +292,21 @@ describe('stock DSH lifecycle', () => {
 
   it('follows the active WebServer port when no setup upstream is configured', async () => {
     const mounted = await mount(false, 43120)
+    expect(mounted.upstreamBase).toBe('http://127.0.0.1:43120')
+  })
+
+  it('follows the active WebServer port instead of a managed setup snapshot', async () => {
+    const setupFile = await managedSetupFile('http://127.0.0.1:3080')
+    const mounted = await mount(false, 43120, { setupFile })
+    expect(mounted.upstreamBase).toBe('http://127.0.0.1:43120')
+  })
+
+  it('ignores a legacy setup upstream snapshot when DSH selects another port', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-mobile-legacy-plugin-'))
+    temporaryDirectories.push(directory)
+    const setupFile = join(directory, 'setup.json')
+    await writeFile(setupFile, JSON.stringify({ version: 1, upstreamOrigin: 'http://127.0.0.1:3080' }))
+    const mounted = await mount(false, 43120, { setupFile })
     expect(mounted.upstreamBase).toBe('http://127.0.0.1:43120')
   })
 


### PR DESCRIPTION
## Summary

- keep the community pane markers from #67 while naming them as legacy dsh-web compatibility hooks
- preserve the rightbar track/fullscreen state contributed in #66, but solve the actual dock width from the left-navigation state, a 300–460 px rightbar range, and a protected 400 px conversation width; insufficient space falls back to a modal overlay with a scrim
- scope the full-width question and plan-review overrides to viewports at most 600 px wide, restoring the native DSH card width on desktop-sized remote clients (#64)
- follow the active DSH WebServer port for LAN and remote authentication even when managed or legacy setup files saved an old 3080 upstream; the Mobile HTTPS listener remains independently configurable (#68)

No Android source or pairing protocol changes are included.

## Verification

- `npm run verify`: 426 passed, 3 skipped; typecheck, build, package checks, and dry-run pack passed
- focused layout / plugin / managed-setup run: 77 passed
- real port chain: managed setup retained `127.0.0.1:3080`, DSH ran on `43120`, Mobile HTTPS remained on `3443`, temporary pairing returned 201, and the authenticated dedicated frontend returned 200; the temporary test device was revoked afterward
- real Android WebView (`io.github.sayach.dshmobile` 0.3.15, versionCode 60): 360 px rightbar used a 338 px modal with the left drawer hidden; responsive probes produced 900/collapsed → 405 px dock + 439 px conversation, 900/expanded → modal + scrim, 1040/expanded → 300 px dock + 400 px conversation, and 1200/expanded → 460 px dock + 400 px conversation
- real `ask_user_question` round: 360 px retained the touch card (`max-width:none`, 16 px radius); 900 px retained the native card (`max-width:680px`, 20 px radius)

## UI evidence

![Responsive rightbar and question-card verification](https://github.com/saya-ch/dsh-mobile/blob/codex/release-0.3.16-assets/layout-e2a05af.gif?raw=true)

Recorded from commit `e2a05afe90c56c84c08d535a98ddccb6dd48bf1c` served by the real `dsh-mobile` candidate through DSH `0.1.5-rc.2-c291e79-dirty` and the paired Android WebView. The successful question round used the configured `muse-spark-1.3-contributor` model; an earlier DeepSeek Official attempt failed with `QUOTA` and is not present in this clean recording. The GIF uses three screenshots from one server/session at 900×800 with 2 s, 2 s, and 4 s holds; no playback speed change or fixture transport was used.

The GIF lives on the media-only orphan branch `codex/release-0.3.16-assets`; no binary is committed to this PR branch.