### PR TITLE
release: prepare dsh-mobile 0.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 Notable changes to DSH Mobile are recorded here. GitHub Releases remain the source for downloadable packages and complete generated commit notes.
 
 
-## Unreleased
+## 0.3.16 - 2026-09-12
 
 - Provide legacy dsh-web community pane markers and a collapsed-rail marker on the dedicated layout so DOM-mounting plugins such as `@linxin666/dsh-client-ui-task-board` can inject their sidebar entry and panel (thanks @idoall for PR #67).
 - Preserve native rightbar track/fullscreen requests while shrinking or overlaying the panel whenever docking would leave less than 400 px for the conversation. The dedicated layout no longer consumes the retired Better Sidebar width variable (thanks @idoall for PR #66).
 - Follow the active DSH WebServer port for LAN and remote proxy authentication, including managed and legacy setup files that saved an older 3080 upstream. The independently configurable Mobile HTTPS listener remains unchanged (thanks @CharlesLueng for #68).
 - Limit the full-width question and plan-review adaptations to screens at most 600 px wide so desktop remote browsers retain DSH's native card width (thanks @idoall for #64).
+
+### Contributors
+
+- @idoall contributed PRs #66 and #67 and reported #64: responsive rightbar docking, legacy dsh-web community pane compatibility, and the question-card reproduction.
+- @CharlesLueng reported #68 and identified the custom DSH Web port path that still targeted the saved default upstream.
 
 ## 0.3.15 - 2026-09-11
 

--- a/README.en.md
+++ b/README.en.md
@@ -19,14 +19,14 @@
 
 > DSH Mobile is a DeepSeek Harness community plugin; the native app supports Android only.
 >
-> **0.3.15 update**: fully adapts to DeepSeek Harness **0.1.5-rc.2**, improves the new frontend and cpolar address rotation and slow first loads, and fixes right-sidebar dismissal, wide-screen scrims, terminal WebSockets, shared desktop footer layout, and reasoning/reply spacing. [Details](CHANGELOG.md).
+> **0.3.16 update**: supports community task-board pane anchors, improves wide-screen rightbar docking and phone question cards, and fixes custom DSH Web ports still targeting the saved default upstream. [Details](CHANGELOG.md).
 >
-> **Upgrade reminder**: DSH 0.1.5 requires plugin **0.3.15** and a DSH restart. Existing pairings remain valid; cpolar users should also install app 0.3.15 so an older app does not cancel a slow first load. [Compatibility notes](#compatibility).
+> **Upgrade reminder**: update the plugin to **0.3.16** and restart DSH. Existing pairings and app 0.3.15 remain compatible; the 0.3.16 APK changes only Android version metadata, so the app update is optional. [Compatibility notes](#compatibility).
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.15/dsh-mobile-android-v0.3.15.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.15/dsh-mobile-android-v0.3.15.apk"><strong>Download Android app 0.3.15</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.15">Release notes and checksums</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.16/dsh-mobile-android-v0.3.16.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile Android app icon" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.16/dsh-mobile-android-v0.3.16.apk"><strong>Download Android app 0.3.16</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.16">Release notes and checksums</a></sub>
 </p>
 
 DSH Mobile is a DeepSeek Harness plugin that lets a mobile browser or the Android app connect over a protected LAN or an optional Tailscale Funnel, cpolar, or self-hosted FRP remote path. Local and remote access keep the same sessions, Workspaces, messages, and tools while using separate switches and paired-device stores without modifying DeepSeek Harness source.
@@ -203,7 +203,7 @@ The table below lists, for each plugin version, the DeepSeek Harness version it 
 
 | DSH Mobile plugin | Verified DeepSeek Harness version |
 | --- | --- |
-| `0.3.15` | `0.1.5-rc.2` (contract check); `0.1.5-rc.1` (@idoall LAN verification) |
+| `0.3.15`, `0.3.16` | `0.1.5-rc.2` (contract check); `0.1.5-rc.1` (@idoall LAN verification) |
 | `0.3.14` | `0.1.3-alpha.2` |
 | `0.3.9`-`0.3.12` | `0.1.3-alpha.1` |
 | `0.3.6`-`0.3.8` | `0.1.2-rc.1` |
@@ -211,7 +211,7 @@ The table below lists, for each plugin version, the DeepSeek Harness version it 
 | `0.3.0`-`0.3.3` | `0.1.2-alpha.1` |
 | `0.1.4`, `0.2.x` | `0.1.1-rc.2` |
 
-Existing 0.3.3–0.3.15 apps do not need re-pairing. cpolar users should update to app 0.3.15 because earlier apps may time out before a slow first load over the free route finishes; earlier apps also use a different status-bar strategy. App 0.1.3 or earlier requires reinstalling and pairing again.
+Existing 0.3.3–0.3.16 apps do not need re-pairing. cpolar users should use app 0.3.15 or later because earlier apps may time out before a slow first load over the free route finishes; earlier apps also use a different status-bar strategy. App 0.1.3 or earlier requires reinstalling and pairing again.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 > DSH Mobile 是 DeepSeek Harness 社区插件，原生 App 仅支持 Android。
 >
-> **0.3.15 更新**：完整适配 DeepSeek Harness **0.1.5-rc.2**，提升新版前端及 cpolar 换址、慢速首屏加载的稳定性，并修复移动右栏关闭、宽屏遮罩、终端 WebSocket、桌面 footer 共存及思考/正文间距。[详细记录](CHANGELOG.md)。
+> **0.3.16 更新**：兼容社区任务看板的移动布局锚点，优化宽屏右栏与手机提问卡片，并修复自定义 DSH Web 端口仍连接旧默认端口的问题。[详细记录](CHANGELOG.md)。
 >
-> **升级提醒**：DSH 0.1.5 用户需将插件升级至 **0.3.15** 并重启 DSH；现有配对继续有效，cpolar 用户需同步安装 0.3.15 App，以免慢速首屏被旧版 App 提前终止。[兼容说明](#兼容性)。
+> **升级提醒**：建议将插件升级至 **0.3.16** 并重启 DSH；现有配对与 0.3.15 App 保持兼容，本次 Android App 仅同步版本号，可按需更新。[兼容说明](#兼容性)。
 
 <p align="center">
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.15/dsh-mobile-android-v0.3.15.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
-  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.15/dsh-mobile-android-v0.3.15.apk"><strong>下载 Android App 0.3.15</strong></a><br>
-  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.15">版本说明与校验文件</a></sub>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.16/dsh-mobile-android-v0.3.16.apk"><img src="assets/brand/app-icon-rounded.svg" alt="DSH Mobile 安卓应用图标" width="72" height="72"></a><br>
+  <a href="https://github.com/saya-ch/dsh-mobile/releases/download/v0.3.16/dsh-mobile-android-v0.3.16.apk"><strong>下载 Android App 0.3.16</strong></a><br>
+  <sub><a href="https://github.com/saya-ch/dsh-mobile/releases/tag/v0.3.16">版本说明与校验文件</a></sub>
 </p>
 
 DSH Mobile 是一个 DeepSeek Harness 插件，让手机浏览器或 Android App 通过局域网，或可选的 Tailscale Funnel、cpolar、自建 FRP 远程通道连接电脑，继续使用同一份会话、工作区、消息和工具。局域网与远程访问分别启停、分别管理设备，且都不修改 DeepSeek Harness 源码。
@@ -212,7 +212,7 @@ flowchart LR
 
 | DSH Mobile 插件 | 验证支持的 DeepSeek Harness 版本 |
 | --- | --- |
-| `0.3.15` | `0.1.5-rc.2`（契约检查）；`0.1.5-rc.1`（@idoall 局域网实测） |
+| `0.3.15`、`0.3.16` | `0.1.5-rc.2`（契约检查）；`0.1.5-rc.1`（@idoall 局域网实测） |
 | `0.3.14` | `0.1.3-alpha.2` |
 | `0.3.9`-`0.3.12` | `0.1.3-alpha.1` |
 | `0.3.6`-`0.3.8` | `0.1.2-rc.1` |
@@ -220,7 +220,7 @@ flowchart LR
 | `0.3.0`-`0.3.3` | `0.1.2-alpha.1` |
 | `0.1.4`、`0.2.x` | `0.1.1-rc.2` |
 
-现有 0.3.3–0.3.15 App 无需重新配对；cpolar 用户应升级到 0.3.15 App，较早版本可能在免费线路的慢速首次加载完成前超时；更早的 App 还使用不同的状态栏策略。App 0.1.3 及更早版本需卸载重装并重新配对。
+现有 0.3.3–0.3.16 App 无需重新配对；cpolar 用户应使用 0.3.15 或更新 App，较早版本可能在免费线路的慢速首次加载完成前超时；更早的 App 还使用不同的状态栏策略。App 0.1.3 及更早版本需卸载重装并重新配对。
 
 ## 卸载
 

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "io.github.sayach.dshmobile"
         minSdk = 29
         targetSdk = 36
-        versionCode = 60
-        versionName = "0.3.15"
+        versionCode = 61
+        versionName = "0.3.16"
     }
 
     signingConfigs {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-mobile",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-mobile",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "private": false,
   "description": "DeepSeek Harness 移动端适配与安全访问插件，支持局域网、远程连接、Android App 和手机浏览器。",
   "type": "module",


### PR DESCRIPTION
## Summary

- Finalize the four changes already merged through PRs #66, #67, and #69 as dsh-mobile 0.3.16.
- Align package.json, package-lock.json, and Android metadata at 0.3.16 / versionCode 61.
- Update Chinese and English download links, concise release highlights, compatibility guidance, and contributor credit.

## Compatibility

There is no Android source or pairing-protocol change in this patch. Existing 0.3.15 apps and paired devices remain compatible; the 0.3.16 APK synchronizes version metadata and is optional for existing users.

## Validation

- npm run verify: 426 passed, 3 skipped; typecheck, build, mobile release checks, Funnel license checks, and dry-run package all passed.
- Simulated v0.3.16 release-tag gate passed.
- Android lintDebug, testDebugUnitTest, and assembleDebug passed.
- Built APK manifest reports versionName 0.3.16 and versionCode 61.
- npm candidate contains 21 expected files and is 9.4 MB.

This PR prepares the release only. It does not publish npm, create a tag, or create a GitHub Release.