### PR TITLE
test: allocate gateway ports atomically

### DIFF
--- a/tests/extension-gateway.test.ts
+++ b/tests/extension-gateway.test.ts
@@ -108,7 +108,7 @@ describe('gateway extension namespace', () => {
         { method: 'GET', path: 'bad-content-control', handle: async () => ({ contentType: 'text/plain\u0000', body: 'invalid' }) },
       ],
     })
-    const config = parseGatewayConfig({ listenHost: '127.0.0.1', listenPort: 38082, upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`, publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'], stateFile: join(directory, 'devices.json'), tls: { mode: 'disabled' } })
+    const config = parseGatewayConfig({ listenHost: '127.0.0.1', listenPort: 0, upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`, publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'], stateFile: join(directory, 'devices.json'), tls: { mode: 'disabled' } })
     const gateway = new MobileAccessGateway(config, new MemoryDeviceStore(), service)
     await gateway.start(); cleanups.push(() => gateway.close())
     const opened = await gateway.access.openPairing()
@@ -147,7 +147,7 @@ describe('gateway extension namespace', () => {
     await service.startLocal(extensionRoot, context); cleanups.push(() => service.stopLocal())
     const first = service.manifest()[0]?.generation as string
 
-    const config = parseGatewayConfig({ listenHost: '127.0.0.1', listenPort: 38087, upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`, publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'], stateFile: join(state, 'devices.json'), tls: { mode: 'disabled' } })
+    const config = parseGatewayConfig({ listenHost: '127.0.0.1', listenPort: 0, upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`, publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'], stateFile: join(state, 'devices.json'), tls: { mode: 'disabled' } })
     const gateway = new MobileAccessGateway(config, new MemoryDeviceStore(), service)
     await gateway.start(); cleanups.push(() => gateway.close())
     const origin = gateway.address().origin
@@ -189,7 +189,7 @@ describe('gateway extension namespace', () => {
       routes: [{ method: 'POST', path: 'echo', handle: async request => ({ contentType: 'application/octet-stream', body: request.body }) }],
     })
     const config = parseGatewayConfig({
-      listenHost: '127.0.0.1', listenPort: 38085,
+      listenHost: '127.0.0.1', listenPort: 0,
       upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`,
       publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'],
       stateFile: join(directory, 'devices.json'), tls: { mode: 'disabled' },
@@ -253,7 +253,7 @@ describe('gateway extension namespace', () => {
     const context = new Context(); cleanups.push(() => context.fiber.dispose())
     const service = new MobileAccessService(context)
     service.registerExtension({ schemaVersion: 1, id: 'hello', name: 'Hello', version: '1.0.0' })
-    const config = parseGatewayConfig({ listenHost: '127.0.0.1', listenPort: 38084, upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`, publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'], stateFile: join(directory, 'devices.json'), tls: { mode: 'disabled' } })
+    const config = parseGatewayConfig({ listenHost: '127.0.0.1', listenPort: 0, upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`, publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'], stateFile: join(directory, 'devices.json'), tls: { mode: 'disabled' } })
     const gateway = new MobileAccessGateway(config, new MemoryDeviceStore(), service)
     await gateway.start(); cleanups.push(() => gateway.close())
     const opened = await gateway.access.openPairing()
@@ -286,7 +286,7 @@ describe('gateway extension namespace', () => {
     const context = new Context(); cleanups.push(() => context.fiber.dispose())
     const service = new MobileAccessService(context)
     const config = parseGatewayConfig({
-      listenHost: '127.0.0.1', listenPort: 38086,
+      listenHost: '127.0.0.1', listenPort: 0,
       upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`,
       publicAuthorities: ['127.0.0.1'], allowedCidrs: ['127.0.0.0/8'],
       stateFile: join(directory, 'devices.json'), tls: { mode: 'disabled' },

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -44,7 +44,6 @@ type BatchedBundleResponder = (
 ) => boolean | Promise<boolean>
 
 const cleanups: Array<() => Promise<void>> = []
-const TEST_GATEWAY_PORT = 38080
 const TEST_FAILED_START_PORT = 38081
 const SESSION_HISTORY_PATH = '/api/session.history'
 const COMPRESSIBLE_SCRIPT = 'globalThis.__compressionProbe = true;\n'.repeat(256)
@@ -377,7 +376,7 @@ async function gateway(
 ): Promise<MobileAccessGateway> {
   const resolved = parseGatewayConfig({
     listenHost: '127.0.0.1',
-    listenPort: TEST_GATEWAY_PORT,
+    listenPort: 0,
     upstreamOrigin: `http://127.0.0.1:${String(upstreamPort)}`,
     publicAuthorities: ['127.0.0.1'],
     allowedCidrs: ['127.0.0.0/8'],

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -90,7 +90,7 @@ async function mount(
     },
   } as never)
   await context.plugin({ Config, inject, apply }, {
-    listenPort: 38083,
+    listenPort: 0,
     stateFile: join(directory, 'devices.json'),
     controlFile: join(directory, 'control.json'),
     customCssFile: join(directory, 'mobile.css'),


### PR DESCRIPTION
## Summary

- Replace fixed listener ports in gateway integration fixtures with operating-system allocated loopback ports.
- Cover the extension gateway, shared gateway helper, and plugin lifecycle fixture.
- Leave the intentionally non-listening TLS failure fixture unchanged.

## Failure evidence

Main CI run 34668438005 failed on Ubuntu Node 22 because tests/extension-gateway.test.ts attempted to bind fixed port 38086 and received EADDRINUSE. The same commit passed the PR run and every other lane, confirming a shared-host port collision rather than a product regression.

## Validation

- Related gateway, extension-gateway, and plugin tests: 60 passed.
- Two independent extension-gateway Vitest processes executed concurrently: 5 passed in each process.
- npm run verify: 426 passed, 3 skipped; typecheck, build, release checks, and package dry run passed.

This changes test resource allocation only; published runtime code and the 0.3.16 package contents are unchanged.